### PR TITLE
Document single-operator branch protection workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,12 @@ Every pull request should include:
 
 Keep unrelated refactors out of the same pull request.
 
+Current single-operator rule:
+
+- PRs are still required before merge
+- CI is the main gate
+- approval is not required unless the repository moves back to multi-maintainer review
+
 ## Checks
 
 Current CI runs audit, lint, tests, build, and Playwright auth smoke.
@@ -55,6 +61,11 @@ npm run test:run
 npm run build
 npm run test:e2e:smoke
 ```
+
+Merge policy on GitHub:
+
+- use squash merge
+- let GitHub delete the branch on merge
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ Current baseline:
 Weekly maintenance automation also runs `taskflow-maintenance`, which uploads a dependency health report and updates a tracking issue when findings exist.
 Known deferred update: `eslint@10.x` is intentionally held back until `eslint-config-next` becomes runtime-compatible.
 
+Current GitHub branch policy is tuned for single-operator maintenance:
+
+- pull requests are required
+- CI checks are required
+- approval is not required
+- squash merge is the default
+
 The build script runs through `scripts/run-next-build.mjs`, which suppresses the known
 `baseline-browser-mapping` false-positive warning while preserving the real build exit code and other output.
 

--- a/docs/BRANCH_PROTECTION.md
+++ b/docs/BRANCH_PROTECTION.md
@@ -5,36 +5,49 @@ Apply these settings to `main` in GitHub repository settings.
 ## Required
 
 - require a pull request before merging
-- require approvals: 1 or more
-- require approval of the most recent reviewable push
 - require conversation resolution before merge
 - require status checks before merge
-- include administrators if you want a strict gate
 - block direct pushes
-
-## Status Checks
-
-Start with:
-
-- `test`
-
-Where `test` is the job name from `.github/workflows/taskflow-ci.yml`.
-
-Do not require lint yet. The repository still has existing lint debt outside the current feature scope.
-
-## Optional
-
-- require branches to be up to date before merging
-- require signed commits if your team needs it
 - disable force pushes
 - disable branch deletion
 
+## Status Checks
+
+Current required checks:
+
+- `taskflow-ci / audit`
+- `taskflow-ci / lint`
+- `taskflow-ci / test`
+- `taskflow-ci / build`
+- `taskflow-ci / e2e-smoke`
+
+Keep `strict` status checks enabled so the branch must be up to date before merge.
+
+## Single-Operator Default
+
+For the current single-operator workflow, keep these review gates off:
+
+- require approvals
+- require code owner review
+- dismiss stale approvals
+- include administrators
+
+This keeps `main` protected by CI without deadlocking merges for a solo maintainer.
+
+## Repository Merge Settings
+
+Recommended repository-level merge settings:
+
+- enable squash merge
+- disable merge commits
+- disable rebase merge
+- delete head branch on merge
+
 ## When To Tighten Rules
 
-Add more required checks after the baseline is stable:
+If the repository moves beyond single-operator maintenance, turn these back on:
 
-- lint
-- build
-- e2e smoke tests
-
-Tighten only after those checks are reliable enough not to create constant false failures.
+- require at least one approval
+- require code owner review
+- dismiss stale approvals
+- consider including administrators

--- a/docs/GITHUB_WORKFLOW.md
+++ b/docs/GITHUB_WORKFLOW.md
@@ -89,10 +89,11 @@ Suggested automation rules:
 Configure branch protection for `main` with:
 
 - require pull request before merging
-- require at least one approval
 - require conversation resolution
 - require status checks to pass
 - restrict direct pushes
+- do not allow force pushes
+- do not allow branch deletion
 
 Current CI baseline:
 
@@ -103,8 +104,22 @@ Current CI baseline:
 - `taskflow-ci / build`
 - `taskflow-ci / e2e-smoke`
 
+Single-operator default:
+
+- no required approval
+- no required code owner review
+- no stale review dismissal
+- no admin enforcement
+
 `audit`, `lint`, `test`, `build`, and `e2e-smoke` should all be configured as required checks for `main`.
 See [`LINT_DEBT.md`](./LINT_DEBT.md) for the current lint maintenance rules.
+
+Repository merge settings should be:
+
+- squash merge enabled
+- merge commits disabled
+- rebase merge disabled
+- delete branch on merge enabled
 
 ## Dependency Maintenance
 
@@ -145,6 +160,12 @@ Automation candidates to revisit later:
 - set `In Progress` when a linked PR opens
 - set `Review` when a PR is marked ready for review
 - set `Done` on merge or close with resolution
+
+If the project adds more maintainers later, re-enable:
+
+- required approval
+- code owner review
+- stale review dismissal
 
 Recommended dependency PR policy:
 


### PR DESCRIPTION
## Summary

- update branch protection docs to match the current single-operator GitHub settings
- clarify that CI is the main gate while approvals and code owner review are disabled for solo maintenance
- document squash-only merge policy and branch auto-deletion

## Linked Issue

Closes #10

## Verification

- [x] docs updated to match current GitHub settings
- [x] no code changes

## Impact

- Affected areas: contribution and workflow documentation
- Breaking changes: none
- Follow-up work: re-enable approval-based guidance if the repository returns to multi-maintainer review
