### PR TITLE
Fix API key creation error visibility

### DIFF
--- a/src/app/(dashboard)/settings/api-keys/page.tsx
+++ b/src/app/(dashboard)/settings/api-keys/page.tsx
@@ -30,6 +30,10 @@ import {
 } from '@/components/ui/alert-dialog';
 import { Key, Plus, Copy, Trash2, ArrowLeft, CheckCircle2, AlertTriangle } from 'lucide-react';
 import Link from 'next/link';
+import {
+  formatApiTokenErrorMessage,
+  readApiTokenError,
+} from '@/lib/auth/apiTokenErrors';
 import type { ApiKey, ApiKeyPermission, ApiKeyCreateData } from '@/types/apiKey';
 import { PERMISSION_GROUPS } from '@/types/apiKey';
 
@@ -37,13 +41,17 @@ export default function ApiKeysPage() {
   const { user, firebaseUser } = useAuth();
   const [apiKeys, setApiKeys] = useState<ApiKey[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const [newKeyName, setNewKeyName] = useState('');
   const [selectedPermissions, setSelectedPermissions] = useState<ApiKeyPermission[]>(['tasks:read']);
   const [isCreating, setIsCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
   const [newPlainTextKey, setNewPlainTextKey] = useState<string | null>(null);
   const [copiedKey, setCopiedKey] = useState(false);
   const [keyToDelete, setKeyToDelete] = useState<ApiKey | null>(null);
+  const [listActionError, setListActionError] = useState<string | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const getAuthHeaders = useCallback(async () => {
     if (!firebaseUser) {
@@ -58,15 +66,21 @@ export default function ApiKeysPage() {
   }, [firebaseUser]);
 
   const loadApiKeys = useCallback(async () => {
-    if (!user?.id || !firebaseUser) return;
+    if (!user?.id || !firebaseUser) {
+      setLoadError('ログイン状態を確認できませんでした。ページを再読み込みして、もう一度お試しください。');
+      setIsLoading(false);
+      return;
+    }
+
     setIsLoading(true);
+    setLoadError(null);
     try {
       const response = await fetch('/api/auth/tokens', {
         headers: await getAuthHeaders(),
       });
 
       if (!response.ok) {
-        throw new Error('Failed to load API keys');
+        throw new Error(await readApiTokenError(response, 'APIキーの取得に失敗しました。'));
       }
 
       const data = await response.json() as { apiKeys: ApiKey[] };
@@ -78,7 +92,15 @@ export default function ApiKeysPage() {
           expiresAt: key.expiresAt ? new Date(key.expiresAt) : null,
         }))
       );
+      setListActionError(null);
     } catch (error) {
+      setApiKeys([]);
+      setLoadError(
+        formatApiTokenErrorMessage(
+          error instanceof Error ? error.message : null,
+          'APIキーの取得に失敗しました。'
+        )
+      );
       console.error('Failed to load API keys:', error);
     } finally {
       setIsLoading(false);
@@ -92,9 +114,13 @@ export default function ApiKeysPage() {
   }, [firebaseUser, loadApiKeys, user?.id]);
 
   const handleCreateKey = async () => {
-    if (!user?.id || !firebaseUser || !newKeyName.trim()) return;
+    if (!user?.id || !firebaseUser || !newKeyName.trim()) {
+      setCreateError('ログイン状態を確認できませんでした。ページを再読み込みして、もう一度お試しください。');
+      return;
+    }
 
     setIsCreating(true);
+    setCreateError(null);
     try {
       const data: ApiKeyCreateData = {
         name: newKeyName.trim(),
@@ -113,14 +139,21 @@ export default function ApiKeysPage() {
       });
 
       if (!response.ok) {
-        throw new Error('Failed to create API key');
+        throw new Error(await readApiTokenError(response, 'APIキーの作成に失敗しました。'));
       }
 
       const result = await response.json() as { plainTextKey: string };
       const { plainTextKey } = result;
       setNewPlainTextKey(plainTextKey);
+      setListActionError(null);
       await loadApiKeys();
     } catch (error) {
+      setCreateError(
+        formatApiTokenErrorMessage(
+          error instanceof Error ? error.message : null,
+          'APIキーの作成に失敗しました。'
+        )
+      );
       console.error('Failed to create API key:', error);
     } finally {
       setIsCreating(false);
@@ -141,41 +174,73 @@ export default function ApiKeysPage() {
     setSelectedPermissions(['tasks:read']);
     setNewPlainTextKey(null);
     setCopiedKey(false);
+    setCreateError(null);
+  };
+
+  const handleCreateDialogOpenChange = (open: boolean) => {
+    if (!open) {
+      handleCloseCreateDialog();
+      return;
+    }
+    setIsCreateDialogOpen(true);
   };
 
   const handleDeactivateKey = async (key: ApiKey) => {
-    if (!user?.id || !firebaseUser) return;
+    if (!user?.id || !firebaseUser) {
+      setListActionError('ログイン状態を確認できませんでした。ページを再読み込みして、もう一度お試しください。');
+      return;
+    }
+
     try {
+      setListActionError(null);
       const response = await fetch(`/api/auth/tokens/${key.id}`, {
         method: 'PATCH',
         headers: await getAuthHeaders(),
       });
 
       if (!response.ok) {
-        throw new Error('Failed to deactivate API key');
+        throw new Error(await readApiTokenError(response, 'APIキーの無効化に失敗しました。'));
       }
 
       await loadApiKeys();
     } catch (error) {
+      setListActionError(
+        formatApiTokenErrorMessage(
+          error instanceof Error ? error.message : null,
+          'APIキーの無効化に失敗しました。'
+        )
+      );
       console.error('Failed to deactivate API key:', error);
     }
   };
 
   const handleDeleteKey = async () => {
-    if (!user?.id || !firebaseUser || !keyToDelete) return;
+    if (!user?.id || !firebaseUser || !keyToDelete) {
+      setDeleteError('ログイン状態を確認できませんでした。ページを再読み込みして、もう一度お試しください。');
+      return;
+    }
+
     try {
+      setDeleteError(null);
+      setListActionError(null);
       const response = await fetch(`/api/auth/tokens/${keyToDelete.id}`, {
         method: 'DELETE',
         headers: await getAuthHeaders(),
       });
 
       if (!response.ok) {
-        throw new Error('Failed to delete API key');
+        throw new Error(await readApiTokenError(response, 'APIキーの削除に失敗しました。'));
       }
 
       await loadApiKeys();
       setKeyToDelete(null);
     } catch (error) {
+      const message = formatApiTokenErrorMessage(
+        error instanceof Error ? error.message : null,
+        'APIキーの削除に失敗しました。'
+      );
+      setDeleteError(message);
+      setListActionError(message);
       console.error('Failed to delete API key:', error);
     }
   };
@@ -247,7 +312,7 @@ export default function ApiKeysPage() {
                 MCPサーバーやその他の外部ツールで使用するAPIキーです
               </CardDescription>
             </div>
-            <Dialog open={isCreateDialogOpen} onOpenChange={setIsCreateDialogOpen}>
+            <Dialog open={isCreateDialogOpen} onOpenChange={handleCreateDialogOpenChange}>
               <DialogTrigger asChild>
                 <Button>
                   <Plus className="mr-2 h-4 w-4" />
@@ -339,6 +404,12 @@ export default function ApiKeysPage() {
                           </div>
                         ))}
                       </div>
+                      {createError ? (
+                        <div className="flex items-start gap-2 rounded-md bg-destructive/10 p-3">
+                          <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0 text-destructive" />
+                          <span className="text-sm text-destructive">{createError}</span>
+                        </div>
+                      ) : null}
                     </div>
                     <DialogFooter>
                       <Button variant="outline" onClick={handleCloseCreateDialog}>
@@ -360,6 +431,19 @@ export default function ApiKeysPage() {
         <CardContent>
           {isLoading ? (
             <div className="py-8 text-center text-muted-foreground">読み込み中...</div>
+          ) : loadError ? (
+            <div className="space-y-4 rounded-lg border border-destructive/30 bg-destructive/10 p-4">
+              <div className="flex items-start gap-3">
+                <AlertTriangle className="mt-0.5 h-5 w-5 flex-shrink-0 text-destructive" />
+                <div className="space-y-1">
+                  <p className="font-medium text-destructive">APIキーを読み込めませんでした</p>
+                  <p className="text-sm text-destructive">{loadError}</p>
+                </div>
+              </div>
+              <Button variant="outline" onClick={() => void loadApiKeys()}>
+                再読み込み
+              </Button>
+            </div>
           ) : apiKeys.length === 0 ? (
             <div className="py-8 text-center text-muted-foreground">
               <Key className="mx-auto h-12 w-12 opacity-30" />
@@ -368,6 +452,12 @@ export default function ApiKeysPage() {
             </div>
           ) : (
             <div className="space-y-4">
+              {listActionError ? (
+                <div className="flex items-start gap-2 rounded-md bg-destructive/10 p-3">
+                  <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0 text-destructive" />
+                  <span className="text-sm text-destructive">{listActionError}</span>
+                </div>
+              ) : null}
               {apiKeys.map((key) => (
                 <div
                   key={key.id}
@@ -456,7 +546,15 @@ export default function ApiKeysPage() {
         </CardContent>
       </Card>
 
-      <AlertDialog open={!!keyToDelete} onOpenChange={() => setKeyToDelete(null)}>
+      <AlertDialog
+        open={!!keyToDelete}
+        onOpenChange={(open) => {
+          if (!open) {
+            setKeyToDelete(null);
+            setDeleteError(null);
+          }
+        }}
+      >
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>APIキーを削除しますか？</AlertDialogTitle>
@@ -465,6 +563,12 @@ export default function ApiKeysPage() {
               このキーを使用しているすべてのアプリケーションは動作しなくなります。
             </AlertDialogDescription>
           </AlertDialogHeader>
+          {deleteError ? (
+            <div className="flex items-start gap-2 rounded-md bg-destructive/10 p-3">
+              <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0 text-destructive" />
+              <span className="text-sm text-destructive">{deleteError}</span>
+            </div>
+          ) : null}
           <AlertDialogFooter>
             <AlertDialogCancel>キャンセル</AlertDialogCancel>
             <AlertDialogAction

--- a/src/app/api/auth/tokens/route.ts
+++ b/src/app/api/auth/tokens/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { verifyAuthToken } from '@/lib/firebase/admin';
 import { createApiToken, listApiTokens } from '@/lib/auth/apiTokens';
+import { getApiTokenRouteError } from '@/lib/auth/apiTokenErrors';
 import type { ApiKey, ApiKeyCreateData, ApiKeyPermission } from '@/types/apiKey';
 
 function isApiKeyPermission(value: string): value is ApiKeyPermission {
@@ -27,8 +28,7 @@ export async function GET(request: NextRequest) {
     const apiKeys = await listApiTokens(user.uid);
     return NextResponse.json({ apiKeys: apiKeys.map(sanitizeApiKey) });
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Internal server error';
-    const status = message.includes('Authorization') ? 401 : 500;
+    const { message, status } = getApiTokenRouteError(error);
     return NextResponse.json({ error: message }, { status });
   }
 }
@@ -73,8 +73,7 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({ apiKey: sanitizeApiKey(apiKey), plainTextKey }, { status: 201 });
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Internal server error';
-    const status = message.includes('Authorization') ? 401 : 500;
+    const { message, status } = getApiTokenRouteError(error);
     return NextResponse.json({ error: message }, { status });
   }
 }

--- a/src/lib/auth/apiTokenErrors.test.ts
+++ b/src/lib/auth/apiTokenErrors.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatApiTokenErrorMessage,
+  getApiTokenRouteError,
+  readApiTokenError,
+} from './apiTokenErrors';
+
+describe('apiTokenErrors', () => {
+  describe('formatApiTokenErrorMessage', () => {
+    it('maps missing Firebase Admin credentials to an actionable message', () => {
+      expect(
+        formatApiTokenErrorMessage(
+          'Could not load the default credentials. Browse to https://cloud.google.com/docs/authentication/getting-started for more information.',
+          'APIキーの作成に失敗しました。'
+        )
+      ).toContain('FIREBASE_SERVICE_ACCOUNT_KEY');
+    });
+
+    it('maps expired auth to a retryable session message', () => {
+      expect(
+        formatApiTokenErrorMessage(
+          'Firebase ID token has expired. Get a fresh token from your client app and try again.',
+          'APIキーの取得に失敗しました。'
+        )
+      ).toContain('ページを再読み込み');
+    });
+
+    it('falls back for generic internal errors', () => {
+      expect(
+        formatApiTokenErrorMessage('Internal Server Error', 'APIキーの取得に失敗しました。')
+      ).toBe('APIキーの取得に失敗しました。');
+    });
+  });
+
+  describe('getApiTokenRouteError', () => {
+    it('returns a 500 with a credential-specific message', () => {
+      expect(
+        getApiTokenRouteError(
+          new Error('Could not load the default credentials. Use GOOGLE_APPLICATION_CREDENTIALS.')
+        )
+      ).toEqual({
+        status: 500,
+        message:
+          'Firebase Admin credentials are not configured. Set FIREBASE_SERVICE_ACCOUNT_KEY or GOOGLE_APPLICATION_CREDENTIALS.',
+      });
+    });
+
+    it('returns a 401 for auth failures', () => {
+      expect(
+        getApiTokenRouteError(new Error('Missing or invalid Authorization header'))
+      ).toEqual({
+        status: 401,
+        message: 'Authentication failed. Refresh your session and try again.',
+      });
+    });
+  });
+
+  describe('readApiTokenError', () => {
+    it('reads and formats the JSON error payload', async () => {
+      const response = new Response(
+        JSON.stringify({
+          error:
+            'Firebase Admin credentials are not configured. Set FIREBASE_SERVICE_ACCOUNT_KEY or GOOGLE_APPLICATION_CREDENTIALS.',
+        }),
+        {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      );
+
+      await expect(
+        readApiTokenError(response, 'APIキーの作成に失敗しました。')
+      ).resolves.toContain('FIREBASE_SERVICE_ACCOUNT_KEY');
+    });
+  });
+});

--- a/src/lib/auth/apiTokenErrors.ts
+++ b/src/lib/auth/apiTokenErrors.ts
@@ -1,0 +1,96 @@
+const FIREBASE_ADMIN_CREDENTIAL_PATTERNS = [
+  'Could not load the default credentials',
+  'GOOGLE_APPLICATION_CREDENTIALS',
+  'FIREBASE_SERVICE_ACCOUNT_KEY',
+  'Service account object must contain',
+  'Failed to parse private key',
+  'private_key',
+  'client_email',
+  'project_id',
+];
+
+const AUTHORIZATION_ERROR_PATTERNS = [
+  'Missing or invalid Authorization header',
+  'Not authenticated',
+  'auth/id-token-expired',
+  'auth/id-token-revoked',
+  'Firebase ID token has expired',
+  'Decoding Firebase ID token failed',
+  'argument-error',
+];
+
+function includesKnownPattern(message: string, patterns: string[]): boolean {
+  return patterns.some((pattern) => message.includes(pattern));
+}
+
+function normalizeMessage(message: string | null | undefined): string {
+  return typeof message === 'string' ? message.trim() : '';
+}
+
+export function isFirebaseAdminCredentialError(message: string): boolean {
+  return includesKnownPattern(message, FIREBASE_ADMIN_CREDENTIAL_PATTERNS);
+}
+
+export function isApiTokenAuthorizationError(message: string): boolean {
+  return includesKnownPattern(message, AUTHORIZATION_ERROR_PATTERNS);
+}
+
+export function formatApiTokenErrorMessage(
+  message: string | null | undefined,
+  fallback: string
+): string {
+  const normalized = normalizeMessage(message);
+
+  if (!normalized || normalized === 'Internal Server Error' || normalized === 'Internal server error') {
+    return fallback;
+  }
+
+  if (isApiTokenAuthorizationError(normalized)) {
+    return '認証の有効期限を確認できませんでした。ページを再読み込みして、もう一度お試しください。';
+  }
+
+  if (isFirebaseAdminCredentialError(normalized)) {
+    return 'サーバー側の Firebase Admin 認証情報が未設定または無効です。FIREBASE_SERVICE_ACCOUNT_KEY または GOOGLE_APPLICATION_CREDENTIALS を設定してください。';
+  }
+
+  return normalized;
+}
+
+export function getApiTokenRouteError(error: unknown): { message: string; status: number } {
+  const rawMessage = error instanceof Error ? error.message : 'Internal server error';
+
+  if (isApiTokenAuthorizationError(rawMessage)) {
+    return {
+      status: 401,
+      message: 'Authentication failed. Refresh your session and try again.',
+    };
+  }
+
+  if (isFirebaseAdminCredentialError(rawMessage)) {
+    return {
+      status: 500,
+      message: 'Firebase Admin credentials are not configured. Set FIREBASE_SERVICE_ACCOUNT_KEY or GOOGLE_APPLICATION_CREDENTIALS.',
+    };
+  }
+
+  return {
+    status: 500,
+    message: normalizeMessage(rawMessage) || 'Internal server error',
+  };
+}
+
+export async function readApiTokenError(
+  response: Response,
+  fallback: string
+): Promise<string> {
+  try {
+    const body = (await response.json()) as { error?: unknown };
+    if (typeof body.error === 'string') {
+      return formatApiTokenErrorMessage(body.error, fallback);
+    }
+  } catch {
+    // Ignore JSON parsing errors and fall back to the HTTP status text.
+  }
+
+  return formatApiTokenErrorMessage(response.statusText, fallback);
+}


### PR DESCRIPTION
## Summary
- surface API key load and create failures directly in the settings UI
- map Firebase Admin credential and auth failures to actionable messages
- add tests for API token error classification

## Testing
- npm run audit
- npm run lint
- npm run test:run
- npm run build
- npm run test:e2e:smoke

Closes #12
