### PR TITLE
Add Firestore indexes for PAT authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,5 +131,5 @@ See [`docs/E2E_STRATEGY.md`](./docs/E2E_STRATEGY.md) for the current test-mode s
 ## Project Notes
 
 - API token management UI is under `src/app/(dashboard)/settings/api-keys/page.tsx`
-- Firebase rules are versioned in `firestore.rules` and `storage.rules`
+- Firebase rules and indexes are versioned in `firestore.rules`, `firestore.indexes.json`, and `storage.rules`
 - Existing AI routes remain under `src/app/api/ai`

--- a/firebase.json
+++ b/firebase.json
@@ -1,6 +1,7 @@
 {
   "firestore": {
-    "rules": "firestore.rules"
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
   },
   "storage": {
     "rules": "storage.rules"

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,66 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "apiTokens",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        {
+          "fieldPath": "isActive",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "keyHash",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "ASCENDING"
+        }
+      ],
+      "density": "SPARSE_ALL"
+    },
+    {
+      "collectionGroup": "notifications",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "userId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "DESCENDING"
+        }
+      ],
+      "density": "SPARSE_ALL"
+    },
+    {
+      "collectionGroup": "projects",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "memberIds",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "isArchived",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "updatedAt",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "DESCENDING"
+        }
+      ],
+      "density": "SPARSE_ALL"
+    }
+  ],
+  "fieldOverrides": []
+}


### PR DESCRIPTION
## Summary
- add the missing Firestore composite index for PAT token lookup
- version the current project Firestore indexes in the repo
- wire Firebase deploy config to `firestore.indexes.json`

## Testing
- python JSON parse validation for `firebase.json` and `firestore.indexes.json`
- `firebase deploy --only firestore:indexes`
- live PAT API verification against `https://taskflow-1000ri.vercel.app`

Closes #14
