### PR TITLE
Fix duplicate IDs for comment attachments

### DIFF
--- a/src/lib/firebase/storage.ts
+++ b/src/lib/firebase/storage.ts
@@ -5,6 +5,10 @@ import {
   deleteObject,
 } from 'firebase/storage';
 import { getFirebaseStorage } from './config';
+import {
+  createCommentAttachmentUploadDescriptor,
+  createUniqueStorageObjectName,
+} from './storageKeys';
 
 export async function uploadFile(
   projectId: string,
@@ -12,8 +16,7 @@ export async function uploadFile(
   file: File
 ): Promise<{ url: string; name: string; type: string; size: number }> {
   const storage = getFirebaseStorage();
-  const timestamp = Date.now();
-  const fileName = `${timestamp}_${file.name}`;
+  const fileName = createUniqueStorageObjectName(file.name);
   const filePath = `projects/${projectId}/tasks/${taskId}/attachments/${fileName}`;
   const fileRef = ref(storage, filePath);
 
@@ -197,8 +200,8 @@ export async function uploadCommentAttachment(
   }
 
   const storage = getFirebaseStorage();
-  const timestamp = Date.now();
-  const fileName = `${timestamp}_${file.name}`;
+  const { attachmentId, storageFileName } = createCommentAttachmentUploadDescriptor(file.name);
+  const fileName = storageFileName;
   const filePath = `projects/${projectId}/tasks/${taskId}/comment_attachments/${fileName}`;
   const fileRef = ref(storage, filePath);
 
@@ -206,7 +209,7 @@ export async function uploadCommentAttachment(
   const url = await getDownloadURL(fileRef);
 
   return {
-    id: `${timestamp}`,
+    id: attachmentId,
     url,
     name: file.name,
     type: file.type,

--- a/src/lib/firebase/storageKeys.test.ts
+++ b/src/lib/firebase/storageKeys.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createCommentAttachmentUploadDescriptor,
+  createUniqueStorageObjectName,
+} from './storageKeys';
+
+describe('storageKeys', () => {
+  it('creates unique storage object names even when timestamps are equal', () => {
+    const first = createUniqueStorageObjectName('image.png', {
+      now: () => 1700000000000,
+      createId: () => 'uuid-a',
+    });
+    const second = createUniqueStorageObjectName('image.png', {
+      now: () => 1700000000000,
+      createId: () => 'uuid-b',
+    });
+
+    expect(first).toBe('1700000000000_uuid-a_image.png');
+    expect(second).toBe('1700000000000_uuid-b_image.png');
+    expect(first).not.toBe(second);
+  });
+
+  it('uses the same generated id for attachment metadata and storage path', () => {
+    const descriptor = createCommentAttachmentUploadDescriptor('photo.jpg', {
+      now: () => 1700000000000,
+      createId: () => 'comment-uuid',
+    });
+
+    expect(descriptor).toEqual({
+      attachmentId: 'comment-uuid',
+      storageFileName: '1700000000000_comment-uuid_photo.jpg',
+    });
+  });
+});

--- a/src/lib/firebase/storageKeys.ts
+++ b/src/lib/firebase/storageKeys.ts
@@ -1,0 +1,39 @@
+function defaultNow(): number {
+  return Date.now();
+}
+
+function defaultCreateId(): string {
+  return crypto.randomUUID();
+}
+
+export function createUniqueStorageObjectName(
+  fileName: string,
+  options?: {
+    now?: () => number;
+    createId?: () => string;
+  }
+): string {
+  const now = options?.now ?? defaultNow;
+  const createId = options?.createId ?? defaultCreateId;
+
+  return `${now()}_${createId()}_${fileName}`;
+}
+
+export function createCommentAttachmentUploadDescriptor(
+  fileName: string,
+  options?: {
+    now?: () => number;
+    createId?: () => string;
+  }
+): { attachmentId: string; storageFileName: string } {
+  const createId = options?.createId ?? defaultCreateId;
+  const attachmentId = createId();
+
+  return {
+    attachmentId,
+    storageFileName: createUniqueStorageObjectName(fileName, {
+      now: options?.now,
+      createId: () => attachmentId,
+    }),
+  };
+}


### PR DESCRIPTION
## Summary
- replace timestamp-only attachment identifiers with UUID-backed identifiers
- make storage object names unique even when multiple files are uploaded in the same millisecond
- add tests for the new storage key helpers

## Testing
- npm run test:run -- src/lib/firebase/storageKeys.test.ts
- npm run lint
- npm run test:run
- npm run build
- npm run test:e2e:smoke

Closes #17
