### PR TITLE
Keep the bottom task composer at the bottom

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,13 @@ Every pull request should include:
 
 Keep unrelated refactors out of the same pull request.
 
+If a GitHub Issue originated from a TaskFlow board task:
+
+- inspect the current implementation first
+- do not mirror the wording blindly
+- leave an `AI triage` comment before implementation
+- close it immediately if it is already implemented on current `main`
+
 Current single-operator rule:
 
 - PRs are still required before merge
@@ -80,3 +87,5 @@ When changing APIs or Firebase data shapes:
 - update the implementation
 - update docs or usage examples
 - call out compatibility concerns in the PR
+
+See [`docs/TASKFLOW_GITHUB_TRIAGE.md`](./docs/TASKFLOW_GITHUB_TRIAGE.md) for the TaskFlow-to-GitHub backlog handoff rules.

--- a/docs/GITHUB_WORKFLOW.md
+++ b/docs/GITHUB_WORKFLOW.md
@@ -84,6 +84,8 @@ Suggested automation rules:
 - PR in review moves Issue to `Review`
 - merged PR closes Issue and moves it to `Done`
 
+For TaskFlow board items that are synced into GitHub Issues, follow the triage rules in [`TASKFLOW_GITHUB_TRIAGE.md`](./TASKFLOW_GITHUB_TRIAGE.md) before implementation starts.
+
 ## Branch Protection
 
 Configure branch protection for `main` with:
@@ -154,6 +156,13 @@ Manual rules:
 - move an issue to `In Progress` when implementation starts, not when it is merely discussed
 - move an issue to `Review` when the linked PR is open
 - move an issue to `Done` only after the change is merged or intentionally completed without code
+
+TaskFlow-imported Issues should not move to `Ready` until they have an explicit `AI triage` comment that classifies them as:
+
+- `already implemented`
+- `partially implemented`
+- `reproducible gap`
+- `needs clarification`
 
 Automation candidates to revisit later:
 

--- a/docs/TASKFLOW_GITHUB_TRIAGE.md
+++ b/docs/TASKFLOW_GITHUB_TRIAGE.md
@@ -1,0 +1,84 @@
+# TaskFlow GitHub Triage
+
+This project uses TaskFlow as the runtime backlog and GitHub as the implementation and review source of truth.
+
+When a TaskFlow board task is brought into GitHub, do not mirror it verbatim without triage.
+
+## Triage Goal
+
+Before implementation starts, classify each imported task into one of these buckets:
+
+- `already implemented`
+- `partially implemented`
+- `reproducible gap`
+- `needs clarification`
+
+This prevents the team from treating ambiguous human requests as clean engineering tasks.
+
+## Required Triage Pass
+
+For every TaskFlow task imported into GitHub:
+
+1. inspect the current UI, API, or code path
+2. decide whether the request is already satisfied
+3. leave an `AI triage` comment on the GitHub Issue
+4. only then decide whether to keep, split, close, or implement the Issue
+
+## Comment Template
+
+Each triage comment should include:
+
+- the current classification
+- what is already implemented today
+- what is still missing
+- what needs clarification, if anything
+- the acceptance gap if implementation is still needed
+
+Preferred opening lines:
+
+- `AI triage: already implemented`
+- `AI triage: partially implemented`
+- `AI triage: reproducible gap`
+- `AI triage: needs clarification`
+
+## Interpretation Rules
+
+When a human writes a vague request such as:
+
+- `hard to align`
+- `I want more file types`
+- `doesn't change`
+
+do not convert it straight into a feature or bug without interpretation.
+
+Instead:
+
+- identify the current implementation that already exists
+- separate UX pain from missing functionality
+- split follow-up issues when a vague request actually mixes multiple concerns
+
+Example:
+
+- `header alignment is hard`
+  - could mean the crop UI exists but is awkward
+  - could mean saved images cannot be re-positioned later
+  - these are different issues and should not be merged blindly
+
+## Close Rules
+
+Close the GitHub Issue when:
+
+- current code already satisfies the request
+- the TaskFlow task is stale and no longer reflects current behavior
+- the real request was split into clearer follow-up issues
+
+When closing as implemented, leave a comment with the current code path or screen behavior that satisfies it.
+
+## Documentation Expectation
+
+Because this repository is explicitly blending project management and development:
+
+- preserve source TaskFlow task IDs in the GitHub Issue body
+- preserve the source board URL when possible
+- document the triage decision in the Issue thread
+- document any new workflow rule in repository docs when the process changes

--- a/src/components/board/BoardList.test.tsx
+++ b/src/components/board/BoardList.test.tsx
@@ -1,0 +1,103 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { BoardList } from './BoardList';
+import type { List, Task } from '@/types';
+
+vi.mock('@dnd-kit/sortable', () => ({
+  SortableContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  verticalListSortingStrategy: {},
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: () => undefined,
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+  }),
+}));
+
+vi.mock('@dnd-kit/core', () => ({
+  useDroppable: () => ({
+    setNodeRef: () => undefined,
+    isOver: false,
+  }),
+}));
+
+vi.mock('./TaskCard', () => ({
+  TaskCard: ({ task }: { task: Task }) => <div>{task.title}</div>,
+}));
+
+const list: List = {
+  id: 'list-1',
+  projectId: 'project-1',
+  name: '依頼事項',
+  color: '#8b5cf6',
+  order: 0,
+  autoCompleteOnEnter: false,
+  autoUncompleteOnExit: false,
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+};
+
+const task: Task = {
+  id: 'task-1',
+  projectId: 'project-1',
+  listId: 'list-1',
+  title: '既存タスク',
+  description: '',
+  order: 0,
+  assigneeIds: [],
+  labelIds: [],
+  tagIds: [],
+  dependsOnTaskIds: [],
+  priority: null,
+  startDate: null,
+  dueDate: null,
+  durationDays: null,
+  isDueDateFixed: false,
+  isCompleted: false,
+  completedAt: null,
+  isAbandoned: false,
+  isArchived: false,
+  archivedAt: null,
+  archivedBy: null,
+  createdBy: 'user-1',
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+};
+
+describe('BoardList', () => {
+  it('keeps the task composer at the bottom when launched from the bottom add button', () => {
+    const onAddTask = vi.fn();
+
+    render(
+      <BoardList
+        projectId="project-1"
+        list={list}
+        tasks={[task]}
+        allTasks={[task]}
+        labels={[]}
+        tags={[]}
+        onAddTask={onAddTask}
+        onEditList={vi.fn()}
+        onDeleteList={vi.fn()}
+        onTaskClick={vi.fn()}
+      />
+    );
+
+    expect(screen.getAllByRole('button', { name: 'タスクを追加' })).toHaveLength(2);
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'タスクを追加' })[1]);
+
+    expect(screen.getByPlaceholderText('タスク名を入力...')).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: 'タスクを追加' })).toHaveLength(1);
+
+    fireEvent.change(screen.getByPlaceholderText('タスク名を入力...'), {
+      target: { value: '末尾で追加するタスク' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '追加' }));
+
+    expect(onAddTask).toHaveBeenCalledWith('末尾で追加するタスク');
+    expect(screen.getAllByRole('button', { name: 'タスクを追加' })).toHaveLength(2);
+  });
+});

--- a/src/components/board/BoardList.tsx
+++ b/src/components/board/BoardList.tsx
@@ -58,7 +58,7 @@ export function BoardList({
   onDeleteList,
   onTaskClick,
 }: BoardListProps) {
-  const [isAddingTask, setIsAddingTask] = useState(false);
+  const [taskComposerPosition, setTaskComposerPosition] = useState<'top' | 'bottom' | null>(null);
   const [newTaskTitle, setNewTaskTitle] = useState('');
   const [isEditingName, setIsEditingName] = useState(false);
   const [editName, setEditName] = useState(list.name);
@@ -87,11 +87,15 @@ export function BoardList({
     data: { type: 'list', listId: list.id },
   });
 
+  const closeTaskComposer = () => {
+    setNewTaskTitle('');
+    setTaskComposerPosition(null);
+  };
+
   const handleAddTask = () => {
     if (newTaskTitle.trim()) {
       onAddTask(newTaskTitle.trim());
-      setNewTaskTitle('');
-      setIsAddingTask(false);
+      closeTaskComposer();
     }
   };
 
@@ -103,8 +107,7 @@ export function BoardList({
     if (e.key === 'Enter') {
       handleAddTask();
     } else if (e.key === 'Escape') {
-      setNewTaskTitle('');
-      setIsAddingTask(false);
+      closeTaskComposer();
     }
   };
 
@@ -230,9 +233,9 @@ export function BoardList({
         </DropdownMenu>
       </div>
 
-      {/* Add Task - At Top */}
+          {/* Add Task - At Top */}
       <div className="flex-shrink-0 px-3 pb-2">
-        {isAddingTask ? (
+        {taskComposerPosition === 'top' ? (
           <div className="space-y-2 rounded-lg border bg-white p-2">
             <Input
               value={newTaskTitle}
@@ -248,10 +251,7 @@ export function BoardList({
               <Button
                 size="sm"
                 variant="ghost"
-                onClick={() => {
-                  setNewTaskTitle('');
-                  setIsAddingTask(false);
-                }}
+                onClick={closeTaskComposer}
               >
                 キャンセル
               </Button>
@@ -261,7 +261,7 @@ export function BoardList({
           <Button
             variant="ghost"
             className="w-full justify-start text-primary hover:text-primary"
-            onClick={() => setIsAddingTask(true)}
+            onClick={() => setTaskComposerPosition('top')}
           >
             <Plus className="mr-1 h-4 w-4" />
             タスクを追加
@@ -293,18 +293,41 @@ export function BoardList({
               ))}
             </SortableContext>
 
-            {/* Add Task Button - After last task */}
-            <button
-              onClick={() => setIsAddingTask(true)}
-              className="flex w-full items-center gap-1 rounded-md py-1.5 text-sm text-gray-400 transition-colors hover:text-gray-600"
-            >
-              <Plus className="h-4 w-4" />
-              <span>タスクを追加</span>
-            </button>
+            {taskComposerPosition === 'bottom' ? (
+              <div className="space-y-2 rounded-lg border bg-white p-2">
+                <Input
+                  value={newTaskTitle}
+                  onChange={(e) => setNewTaskTitle(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  placeholder="タスク名を入力..."
+                  autoFocus
+                />
+                <div className="flex gap-2">
+                  <Button size="sm" onClick={handleAddTask}>
+                    追加
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={closeTaskComposer}
+                  >
+                    キャンセル
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <button
+                onClick={() => setTaskComposerPosition('bottom')}
+                className="flex w-full items-center gap-1 rounded-md py-1.5 text-sm text-gray-400 transition-colors hover:text-gray-600"
+              >
+                <Plus className="h-4 w-4" />
+                <span>タスクを追加</span>
+              </button>
+            )}
           </div>
         </ContextMenuTrigger>
         <ContextMenuContent>
-          <ContextMenuItem onClick={() => setIsAddingTask(true)}>
+          <ContextMenuItem onClick={() => setTaskComposerPosition('bottom')}>
             <Plus className="mr-2 h-4 w-4" />
             新規タスク
           </ContextMenuItem>


### PR DESCRIPTION
## Summary
- keep the add-task composer at the bottom when launched from the bottom button in a board list
- add a component test that covers the bottom composer behavior
- document the TaskFlow-to-GitHub triage workflow so imported board tasks are classified before implementation

## Testing
- npm run audit
- npm run lint
- npm run test:run -- src/components/board/BoardList.test.tsx
- npm run test:run
- npm run build
- npm run test:e2e:smoke

Closes #16
