### PR TITLE
Match project header display to crop ratio

### DIFF
--- a/src/app/(dashboard)/projects/[projectId]/layout.test.tsx
+++ b/src/app/(dashboard)/projects/[projectId]/layout.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import ProjectLayout from './layout';
+import { useProject } from '@/hooks/useProjects';
+import type { Project } from '@/types';
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ projectId: 'project-1' }),
+  usePathname: () => '/projects/project-1/board',
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+vi.mock('next/image', () => ({
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement> & { fill?: boolean }) => {
+    const imageProps = { ...props };
+    delete imageProps.fill;
+
+    return (
+      // next/image is mocked as a regular image for component tests.
+      // eslint-disable-next-line @next/next/no-img-element
+      <img alt={imageProps.alt ?? ''} {...imageProps} />
+    );
+  },
+}));
+
+vi.mock('@/hooks/useProjects', () => ({
+  useProject: vi.fn(),
+}));
+
+const mockedUseProject = vi.mocked(useProject);
+
+const project: Project = {
+  id: 'project-1',
+  name: 'TaskFlow',
+  description: 'Header preview test project',
+  color: '#0f766e',
+  icon: '🚀',
+  iconUrl: undefined,
+  headerImageUrl: 'https://example.com/header.jpg',
+  ownerId: 'user-1',
+  memberIds: ['user-1'],
+  isArchived: false,
+  order: 0,
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+};
+
+describe('ProjectLayout', () => {
+  it('renders the project header banner with the same 5:1 aspect ratio used in the cropper', () => {
+    mockedUseProject.mockReturnValue({
+      project,
+      isLoading: false,
+    } as ReturnType<typeof useProject>);
+
+    render(
+      <ProjectLayout>
+        <div>content</div>
+      </ProjectLayout>
+    );
+
+    expect(screen.getByTestId('project-header-banner')).toHaveClass('aspect-[5/1]');
+    expect(screen.getByAltText('TaskFlow header')).toBeInTheDocument();
+  });
+
+  it('keeps the same banner ratio when no header image is configured', () => {
+    mockedUseProject.mockReturnValue({
+      project: {
+        ...project,
+        headerImageUrl: undefined,
+      },
+      isLoading: false,
+    } as ReturnType<typeof useProject>);
+
+    render(
+      <ProjectLayout>
+        <div>content</div>
+      </ProjectLayout>
+    );
+
+    expect(screen.getByTestId('project-header-banner')).toHaveClass('aspect-[5/1]');
+    expect(screen.queryByAltText('TaskFlow header')).not.toBeInTheDocument();
+  });
+});

--- a/src/app/(dashboard)/projects/[projectId]/layout.tsx
+++ b/src/app/(dashboard)/projects/[projectId]/layout.tsx
@@ -65,7 +65,8 @@ export default function ProjectLayout({
 
         {/* Header Image or Colored Banner */}
         <div
-          className="relative w-full overflow-hidden rounded-lg h-[60px] sm:h-[72px] md:h-[90px] lg:h-[108px]"
+          data-testid="project-header-banner"
+          className="relative aspect-[5/1] w-full overflow-hidden rounded-lg"
           style={{
             backgroundColor: project.headerImageUrl ? undefined : `${project.color}30`,
           }}


### PR DESCRIPTION
## Summary
- render the project header banner with the same 5:1 aspect ratio used by the header cropper
- keep saved header positioning closer to what the settings dialog showed before upload
- add a component test that locks the banner ratio for both image and color fallback states

## Validation
- npm run audit
- npm run lint
- npm run test:run
- npm run build
- npm run test:e2e:smoke

Closes #15