### PR TITLE
Add task comment API for PAT integrations

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -117,6 +117,20 @@ Supports partial update of:
 - isDueDateFixed
 - isCompleted
 
+### `POST /api/projects/[projectId]/tasks/[taskId]/comments`
+
+Requires `tasks:write` and non-viewer project membership.
+
+Supports:
+
+- content
+- mentions
+
+Notes:
+
+- comment author is always the authenticated user
+- attachments are not yet supported through the public API
+
 ### `DELETE /api/projects/[projectId]/tasks/[taskId]`
 
 Archives the task. This is a soft delete.

--- a/docs/API_INTEGRATION.md
+++ b/docs/API_INTEGRATION.md
@@ -122,6 +122,37 @@ curl -X PATCH http://localhost:3000/api/projects/$PROJECT_ID/tasks/$TASK_ID \
   }'
 ```
 
+### Add a task comment
+
+Use this to sync GitHub progress back to the originating TaskFlow task.
+
+```bash
+curl -X POST http://localhost:3000/api/projects/$PROJECT_ID/tasks/$TASK_ID/comments \
+  -H "Authorization: Bearer $TASKFLOW_PAT" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "content": "[AIからのメッセージ]\nGitHub Issue: #26\nGitHub PR: #27\n詳細: comment API を実装中です。",
+    "mentions": []
+  }'
+```
+
+Example response:
+
+```json
+{
+  "comment": {
+    "id": "comment_123",
+    "taskId": "task_123",
+    "content": "[AIからのメッセージ]\nGitHub Issue: #26\nGitHub PR: #27\n詳細: comment API を実装中です。",
+    "authorId": "user_123",
+    "mentions": [],
+    "attachments": [],
+    "createdAt": "2026-03-13T00:00:00.000Z",
+    "updatedAt": "2026-03-13T00:00:00.000Z"
+  }
+}
+```
+
 ### Archive a task
 
 ```bash
@@ -154,7 +185,7 @@ Useful permission combinations:
 - broad admin:
   `["admin"]`
 
-`tasks:write` does not bypass project membership. A viewer-level member still cannot mutate tasks.
+`tasks:write` does not bypass project membership. A viewer-level member still cannot mutate tasks or add API comments.
 
 ## Common Errors
 

--- a/src/app/api/projects/[projectId]/tasks/[taskId]/comments/route.test.ts
+++ b/src/app/api/projects/[projectId]/tasks/[taskId]/comments/route.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { POST } from './route';
+
+vi.mock('@/lib/auth/authenticateRequest', () => ({
+  authenticateRequest: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/projectAccess', () => ({
+  getProjectAccess: vi.fn(),
+}));
+
+vi.mock('@/lib/firebase/admin-projects', () => ({
+  createProjectTaskComment: vi.fn(),
+}));
+
+import { authenticateRequest } from '@/lib/auth/authenticateRequest';
+import { getProjectAccess } from '@/lib/auth/projectAccess';
+import { createProjectTaskComment } from '@/lib/firebase/admin-projects';
+
+const mockedAuthenticateRequest = vi.mocked(authenticateRequest);
+const mockedGetProjectAccess = vi.mocked(getProjectAccess);
+const mockedCreateProjectTaskComment = vi.mocked(createProjectTaskComment);
+
+describe('POST /api/projects/[projectId]/tasks/[taskId]/comments', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockedAuthenticateRequest.mockResolvedValue({
+      userId: 'user-1',
+      authType: 'api-token',
+      permissions: ['tasks:write'],
+      projectIds: null,
+      tokenId: 'token-1',
+    });
+    mockedGetProjectAccess.mockResolvedValue({ role: 'editor' });
+  });
+
+  it('creates a task comment', async () => {
+    mockedCreateProjectTaskComment.mockResolvedValue({
+      comment: {
+        id: 'comment-1',
+        taskId: 'task-1',
+        content: 'AI progress update',
+        authorId: 'user-1',
+        mentions: [],
+        attachments: [],
+        createdAt: '2026-03-13T00:00:00.000Z',
+        updatedAt: '2026-03-13T00:00:00.000Z',
+      },
+    });
+
+    const request = new NextRequest('http://localhost/api/projects/project-1/tasks/task-1/comments', {
+      method: 'POST',
+      body: JSON.stringify({ content: '  AI progress update  ' }),
+      headers: {
+        Authorization: 'Bearer tf_example',
+        'Content-Type': 'application/json',
+      },
+    });
+
+    const response = await POST(request, {
+      params: Promise.resolve({ projectId: 'project-1', taskId: 'task-1' }),
+    });
+
+    expect(response.status).toBe(201);
+    expect(mockedAuthenticateRequest).toHaveBeenCalledWith('Bearer tf_example');
+    expect(mockedGetProjectAccess).toHaveBeenCalledWith('user-1', 'project-1', ['tasks:write'], null, 'tasks:write');
+    expect(mockedCreateProjectTaskComment).toHaveBeenCalledWith('project-1', 'task-1', 'user-1', {
+      content: 'AI progress update',
+      mentions: undefined,
+    });
+    await expect(response.json()).resolves.toEqual({
+      comment: {
+        id: 'comment-1',
+        taskId: 'task-1',
+        content: 'AI progress update',
+        authorId: 'user-1',
+        mentions: [],
+        attachments: [],
+        createdAt: '2026-03-13T00:00:00.000Z',
+        updatedAt: '2026-03-13T00:00:00.000Z',
+      },
+    });
+  });
+
+  it('rejects empty content', async () => {
+    const request = new NextRequest('http://localhost/api/projects/project-1/tasks/task-1/comments', {
+      method: 'POST',
+      body: JSON.stringify({ content: '   ' }),
+      headers: {
+        Authorization: 'Bearer tf_example',
+        'Content-Type': 'application/json',
+      },
+    });
+
+    const response = await POST(request, {
+      params: Promise.resolve({ projectId: 'project-1', taskId: 'task-1' }),
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: 'CONTENT_REQUIRED' });
+    expect(mockedCreateProjectTaskComment).not.toHaveBeenCalled();
+  });
+
+  it('maps viewer access failures to forbidden', async () => {
+    mockedGetProjectAccess.mockRejectedValue(new Error('FORBIDDEN'));
+
+    const request = new NextRequest('http://localhost/api/projects/project-1/tasks/task-1/comments', {
+      method: 'POST',
+      body: JSON.stringify({ content: 'Viewer comment attempt' }),
+      headers: {
+        Authorization: 'Bearer tf_example',
+        'Content-Type': 'application/json',
+      },
+    });
+
+    const response = await POST(request, {
+      params: Promise.resolve({ projectId: 'project-1', taskId: 'task-1' }),
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({ error: 'Forbidden' });
+  });
+});

--- a/src/app/api/projects/[projectId]/tasks/[taskId]/comments/route.ts
+++ b/src/app/api/projects/[projectId]/tasks/[taskId]/comments/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { authenticateRequest } from '@/lib/auth/authenticateRequest';
+import { getProjectAccess } from '@/lib/auth/projectAccess';
+import { createProjectTaskComment } from '@/lib/firebase/admin-projects';
+
+interface RouteContext {
+  params: Promise<{
+    projectId: string;
+    taskId: string;
+  }>;
+}
+
+function parseStringArray(value: unknown, fieldName: string): string[] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (!Array.isArray(value) || !value.every((item) => typeof item === 'string')) {
+    throw new Error(`INVALID_${fieldName.toUpperCase()}`);
+  }
+
+  return value;
+}
+
+function parseCreateCommentBody(body: unknown): { content: string; mentions?: string[] } {
+  if (typeof body !== 'object' || body === null) {
+    throw new Error('INVALID_BODY');
+  }
+
+  const payload = body as Record<string, unknown>;
+
+  if (typeof payload.content !== 'string' || !payload.content.trim()) {
+    throw new Error('CONTENT_REQUIRED');
+  }
+
+  if (payload.attachments !== undefined) {
+    throw new Error('ATTACHMENTS_NOT_SUPPORTED');
+  }
+
+  return {
+    content: payload.content.trim(),
+    mentions: parseStringArray(payload.mentions, 'mentions'),
+  };
+}
+
+export async function POST(request: NextRequest, context: RouteContext) {
+  try {
+    const auth = await authenticateRequest(request.headers.get('Authorization'));
+    const { projectId, taskId } = await context.params;
+
+    await getProjectAccess(
+      auth.userId,
+      projectId,
+      auth.permissions,
+      auth.projectIds,
+      'tasks:write'
+    );
+
+    const body = await request.json();
+    const commentInput = parseCreateCommentBody(body);
+    const result = await createProjectTaskComment(projectId, taskId, auth.userId, commentInput);
+    return NextResponse.json(result, { status: 201 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Internal server error';
+
+    if (message === 'FORBIDDEN') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    if (message === 'NOT_FOUND') {
+      return NextResponse.json({ error: 'Task not found' }, { status: 404 });
+    }
+
+    if (
+      message === 'INVALID_BODY' ||
+      message === 'CONTENT_REQUIRED' ||
+      message === 'ATTACHMENTS_NOT_SUPPORTED' ||
+      message.startsWith('INVALID_')
+    ) {
+      return NextResponse.json({ error: message }, { status: 400 });
+    }
+
+    const status = message.includes('Authorization') || message === 'Invalid API token' ? 401 : 500;
+    return NextResponse.json({ error: message }, { status });
+  }
+}

--- a/src/lib/firebase/admin-projects.ts
+++ b/src/lib/firebase/admin-projects.ts
@@ -1,4 +1,4 @@
-import type { Priority, Task } from '@/types';
+import type { CommentAttachment, Priority, Task } from '@/types';
 import { checkDeadlineOverdue, validateTask } from '@/lib/ai/tools/validation';
 import { calculateEffectiveStartDate, recalculateDates } from '@/lib/utils/task';
 import { getAdminDb } from './admin';
@@ -75,6 +75,17 @@ export interface ProjectTaskItem {
   startDate: string | null;
   dueDate: string | null;
   isCompleted: boolean;
+  updatedAt: string | null;
+}
+
+export interface ProjectTaskCommentItem {
+  id: string;
+  taskId: string;
+  content: string;
+  authorId: string;
+  mentions: string[];
+  attachments: CommentAttachment[];
+  createdAt: string | null;
   updatedAt: string | null;
 }
 
@@ -187,6 +198,39 @@ function mapTaskToApiItem(task: Task): ProjectTaskItem {
     dueDate: task.dueDate ? task.dueDate.toISOString() : null,
     isCompleted: task.isCompleted,
     updatedAt: task.updatedAt ? task.updatedAt.toISOString() : null,
+  };
+}
+
+function mapCommentToApiItem(
+  taskId: string,
+  commentId: string,
+  data: Record<string, unknown>
+): ProjectTaskCommentItem {
+  return {
+    id: commentId,
+    taskId,
+    content: typeof data.content === 'string' ? data.content : '',
+    authorId: typeof data.authorId === 'string' ? data.authorId : '',
+    mentions:
+      Array.isArray(data.mentions) && data.mentions.every((item) => typeof item === 'string')
+        ? data.mentions
+        : [],
+    attachments:
+      Array.isArray(data.attachments) &&
+      data.attachments.every(
+        (item) =>
+          typeof item === 'object' &&
+          item !== null &&
+          typeof item.id === 'string' &&
+          typeof item.name === 'string' &&
+          typeof item.url === 'string' &&
+          typeof item.type === 'string' &&
+          typeof item.size === 'number'
+      )
+        ? (data.attachments as CommentAttachment[])
+        : [],
+    createdAt: toIsoString(data.createdAt),
+    updatedAt: toIsoString(data.updatedAt),
   };
 }
 
@@ -637,5 +681,48 @@ export async function restoreProjectTask(
 
   return {
     task: mapTaskToApiItem(task),
+  };
+}
+
+export async function createProjectTaskComment(
+  projectId: string,
+  taskId: string,
+  userId: string,
+  input: {
+    content: string;
+    mentions?: string[];
+  }
+): Promise<{ comment: ProjectTaskCommentItem }> {
+  const db = getAdminDb();
+  const existingTask = await getProjectTaskInternal(projectId, taskId);
+
+  if (!existingTask || existingTask.isArchived) {
+    throw new Error('NOT_FOUND');
+  }
+
+  const now = new Date();
+  const commentRef = await db
+    .collection('projects')
+    .doc(projectId)
+    .collection('tasks')
+    .doc(taskId)
+    .collection('comments')
+    .add({
+      taskId,
+      content: input.content,
+      authorId: userId,
+      mentions: input.mentions ?? [],
+      attachments: [],
+      createdAt: now,
+      updatedAt: now,
+    });
+
+  const commentSnapshot = await commentRef.get();
+  if (!commentSnapshot.exists) {
+    throw new Error('COMMENT_CREATE_FAILED');
+  }
+
+  return {
+    comment: mapCommentToApiItem(taskId, commentSnapshot.id, commentSnapshot.data() as Record<string, unknown>),
   };
 }


### PR DESCRIPTION
## Summary
- add `POST /api/projects/[projectId]/tasks/[taskId]/comments` for Firebase and PAT-authenticated integrations
- store API-created comments in the same Firestore structure used by the UI and cover the route with unit tests
- document the comment API and a sync-back curl example for TaskFlow/GitHub workflows

## Validation
- npm run audit
- npm run lint
- npm run test:run
- npm run build
- npm run test:e2e:smoke

Closes #26