### PR TITLE
Add AVIF support for project images

### DIFF
--- a/src/app/(dashboard)/projects/[projectId]/settings/page.tsx
+++ b/src/app/(dashboard)/projects/[projectId]/settings/page.tsx
@@ -22,6 +22,11 @@ import { deleteProjectIcon, uploadProjectIconBlob, uploadProjectHeaderImageBlob,
 import { ImageCropperDialog } from '@/components/common/ImageCropperDialog';
 import { readFileAsDataURL, readImageUrlAsDataURL } from '@/lib/utils/image';
 import {
+  isSupportedProjectImageType,
+  PROJECT_IMAGE_UPLOAD_ACCEPT,
+  PROJECT_IMAGE_UPLOAD_FORMAT_LABEL,
+} from '@/lib/utils/projectImageUpload';
+import {
   Dialog,
   DialogContent,
   DialogDescription,
@@ -148,9 +153,8 @@ export default function ProjectSettingsPage() {
     if (!file) return;
 
     // Validate file type
-    const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
-    if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
-      alert('画像ファイル（JPG, PNG, GIF, WebP）のみアップロード可能です');
+    if (!isSupportedProjectImageType(file.type)) {
+      alert(`画像ファイル（${PROJECT_IMAGE_UPLOAD_FORMAT_LABEL}）のみアップロード可能です`);
       return;
     }
 
@@ -220,9 +224,8 @@ export default function ProjectSettingsPage() {
     if (!file) return;
 
     // Validate file type
-    const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
-    if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
-      alert('画像ファイル（JPG, PNG, GIF, WebP）のみアップロード可能です');
+    if (!isSupportedProjectImageType(file.type)) {
+      alert(`画像ファイル（${PROJECT_IMAGE_UPLOAD_FORMAT_LABEL}）のみアップロード可能です`);
       return;
     }
 
@@ -417,7 +420,7 @@ export default function ProjectSettingsPage() {
                 )}
                 <div className="text-sm text-muted-foreground">
                   <p>{iconUrl ? '画像を再調整または変更' : '画像をアップロード'}</p>
-                  <p className="text-xs">JPG, PNG, GIF, WebP (最大5MB)</p>
+                  <p className="text-xs">{PROJECT_IMAGE_UPLOAD_FORMAT_LABEL} (最大5MB)</p>
                   {iconUrl && (
                     <div className="mt-3 flex flex-wrap gap-2">
                       <Button
@@ -446,7 +449,7 @@ export default function ProjectSettingsPage() {
                 <input
                   ref={fileInputRef}
                   type="file"
-                  accept="image/jpeg,image/png,image/gif,image/webp"
+                  accept={PROJECT_IMAGE_UPLOAD_ACCEPT}
                   onChange={handleIconUpload}
                   className="hidden"
                 />
@@ -588,7 +591,7 @@ export default function ProjectSettingsPage() {
               <input
                 ref={headerFileInputRef}
                 type="file"
-                accept="image/jpeg,image/png,image/gif,image/webp"
+                accept={PROJECT_IMAGE_UPLOAD_ACCEPT}
                 onChange={handleHeaderImageUpload}
                 className="hidden"
               />

--- a/src/lib/firebase/storage.ts
+++ b/src/lib/firebase/storage.ts
@@ -9,6 +9,10 @@ import {
   createCommentAttachmentUploadDescriptor,
   createUniqueStorageObjectName,
 } from './storageKeys';
+import {
+  isSupportedProjectImageType,
+  PROJECT_IMAGE_UPLOAD_FORMAT_LABEL,
+} from '@/lib/utils/projectImageUpload';
 
 export async function uploadFile(
   projectId: string,
@@ -83,15 +87,13 @@ export function formatFileSize(bytes: number): string {
 
 // Maximum file size for project icons (5MB)
 const MAX_ICON_SIZE = 5 * 1024 * 1024;
-const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
-
 export async function uploadProjectIcon(
   projectId: string,
   file: File
 ): Promise<string> {
   // Validate file type
-  if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
-    throw new Error('画像ファイル（JPG, PNG, GIF, WebP）のみアップロード可能です');
+  if (!isSupportedProjectImageType(file.type)) {
+    throw new Error(`画像ファイル（${PROJECT_IMAGE_UPLOAD_FORMAT_LABEL}）のみアップロード可能です`);
   }
 
   // Validate file size

--- a/src/lib/utils/projectImageUpload.test.ts
+++ b/src/lib/utils/projectImageUpload.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import {
+  PROJECT_IMAGE_UPLOAD_ACCEPT,
+  PROJECT_IMAGE_UPLOAD_FORMAT_LABEL,
+  PROJECT_IMAGE_UPLOAD_MIME_TYPES,
+  isSupportedProjectImageType,
+} from './projectImageUpload';
+
+describe('projectImageUpload', () => {
+  it('includes avif in the supported MIME types and accept string', () => {
+    expect(PROJECT_IMAGE_UPLOAD_MIME_TYPES).toContain('image/avif');
+    expect(PROJECT_IMAGE_UPLOAD_ACCEPT).toContain('image/avif');
+    expect(PROJECT_IMAGE_UPLOAD_FORMAT_LABEL).toContain('AVIF');
+  });
+
+  it('recognizes supported and unsupported project image types', () => {
+    expect(isSupportedProjectImageType('image/avif')).toBe(true);
+    expect(isSupportedProjectImageType('image/svg+xml')).toBe(false);
+  });
+});

--- a/src/lib/utils/projectImageUpload.ts
+++ b/src/lib/utils/projectImageUpload.ts
@@ -1,0 +1,17 @@
+export const PROJECT_IMAGE_UPLOAD_MIME_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+  'image/avif',
+] as const;
+
+export const PROJECT_IMAGE_UPLOAD_ACCEPT = PROJECT_IMAGE_UPLOAD_MIME_TYPES.join(',');
+
+export const PROJECT_IMAGE_UPLOAD_FORMAT_LABEL = 'JPG, PNG, GIF, WebP, AVIF';
+
+export function isSupportedProjectImageType(fileType: string): boolean {
+  return PROJECT_IMAGE_UPLOAD_MIME_TYPES.includes(
+    fileType as (typeof PROJECT_IMAGE_UPLOAD_MIME_TYPES)[number]
+  );
+}


### PR DESCRIPTION
## Summary
- add `image/avif` to the supported project icon and header upload types
- centralize project image upload MIME type validation so UI and storage use the same allowlist
- cover the new allowlist with a unit test

## Validation
- npm run audit
- npm run lint
- npm run test:run
- npm run build
- npm run test:e2e:smoke

Closes #19