### PR TITLE
Add per-project AI access control

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,12 @@ Current integration routes:
 - `POST /api/auth/tokens`
 - `PATCH /api/auth/tokens/[tokenId]`
 - `DELETE /api/auth/tokens/[tokenId]`
+- `GET /api/ai/settings`
+- `PATCH /api/ai/settings`
 
 See [`docs/API.md`](./docs/API.md) for the current API surface and auth model.
 See [`docs/API_INTEGRATION.md`](./docs/API_INTEGRATION.md) for curl examples and integration flow.
+See [`docs/AI_ACCESS_CONTROL.md`](./docs/AI_ACCESS_CONTROL.md) for project-level AI access rules.
 See [`docs/GITHUB_WORKFLOW.md`](./docs/GITHUB_WORKFLOW.md) for GitHub workflow rules.
 See [`docs/LINT_DEBT.md`](./docs/LINT_DEBT.md) for current lint status and maintenance rules.
 See [`docs/ESLINT10_TRACKING.md`](./docs/ESLINT10_TRACKING.md) for the deferred ESLint 10 upgrade.
@@ -131,5 +134,6 @@ See [`docs/E2E_STRATEGY.md`](./docs/E2E_STRATEGY.md) for the current test-mode s
 ## Project Notes
 
 - API token management UI is under `src/app/(dashboard)/settings/api-keys/page.tsx`
+- AI project access settings UI is under `src/app/(dashboard)/settings/ai/page.tsx`
 - Firebase rules and indexes are versioned in `firestore.rules`, `firestore.indexes.json`, and `storage.rules`
 - Existing AI routes remain under `src/app/api/ai`

--- a/docs/AI_ACCESS_CONTROL.md
+++ b/docs/AI_ACCESS_CONTROL.md
@@ -1,0 +1,37 @@
+# AI Access Control
+
+TaskFlow supports per-project AI access control for the first-party Companion AI.
+
+## Current Behavior
+
+- AI provider keys remain user-level settings.
+- AI project access is also user-level, but scoped by project.
+- The AI settings screen shows a checkbox for each project the user can access.
+
+## Persistence
+
+- Route: `GET /api/ai/settings`
+- Route: `PATCH /api/ai/settings`
+- Storage: `users/{userId}/settings/aiSettings.allowedProjectIds`
+
+## Semantics
+
+- `allowedProjectIds = null`
+  - AI can access all current and future projects for that user.
+- `allowedProjectIds = ["project-a", "project-b"]`
+  - AI can only access the listed projects.
+  - Other projects are excluded from personal-scope AI context and tools.
+  - Project-scoped AI is disabled on excluded projects.
+
+## Enforcement Points
+
+- Settings UI: checkbox selection per project
+- Companion AI UI: disabled state and guidance when a project is excluded
+- Chat API: rejects project-scoped requests for excluded projects
+- Personal-scope AI context: filtered to the allowed project subset
+
+## First Iteration Limits
+
+- Access control is ON/OFF per project only.
+- No read-only/tools-only/full-access levels yet.
+- External PAT permissions are separate from Companion AI access settings.

--- a/docs/API.md
+++ b/docs/API.md
@@ -43,6 +43,36 @@ Deactivates a token.
 
 Deletes a token.
 
+## First-Party AI Settings Routes
+
+These routes are intended for the authenticated TaskFlow UI, not external PAT integrations.
+
+### `GET /api/ai/settings`
+
+Returns AI project access settings for the current user.
+
+Response shape:
+
+```json
+{
+  "allowedProjectIds": null
+}
+```
+
+`null` means the user's AI can access all current and future projects.
+
+### `PATCH /api/ai/settings`
+
+Updates AI project access settings for the current user.
+
+Request body:
+
+```json
+{
+  "allowedProjectIds": ["project-a", "project-b"]
+}
+```
+
 ## Project Routes
 
 ### `GET /api/projects`

--- a/src/app/api/ai/chat/route.test.ts
+++ b/src/app/api/ai/chat/route.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { POST } from './route';
+
+vi.mock('@/lib/ai/providers', () => ({
+  getProvider: vi.fn(),
+  isValidProvider: vi.fn(() => true),
+}));
+
+vi.mock('@/lib/firebase/admin', () => ({
+  verifyAuthToken: vi.fn(),
+  getUserAIApiKey: vi.fn(),
+  getUserAIProjectAccessSettings: vi.fn(),
+}));
+
+import { getProvider } from '@/lib/ai/providers';
+import {
+  getUserAIApiKey,
+  getUserAIProjectAccessSettings,
+  verifyAuthToken,
+} from '@/lib/firebase/admin';
+
+const mockedGetProvider = vi.mocked(getProvider);
+const mockedVerifyAuthToken = vi.mocked(verifyAuthToken);
+const mockedGetUserAIApiKey = vi.mocked(getUserAIApiKey);
+const mockedGetUserAIProjectAccessSettings = vi.mocked(getUserAIProjectAccessSettings);
+
+describe('POST /api/ai/chat', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockedVerifyAuthToken.mockResolvedValue({ uid: 'user-1' });
+    mockedGetUserAIApiKey.mockResolvedValue('sk-test');
+    mockedGetUserAIProjectAccessSettings.mockResolvedValue({
+      allowedProjectIds: ['project-1'],
+    });
+  });
+
+  it('returns forbidden when the current project is outside the allowed set', async () => {
+    const request = new NextRequest('http://localhost/api/ai/chat', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer firebase-id-token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        messages: [],
+        context: {
+          scope: 'companion',
+          user: { id: 'user-1', displayName: 'User One' },
+          projects: [],
+        },
+        provider: 'openai',
+        projectId: 'project-2',
+      }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: 'このプロジェクトではAIアクセスが無効です。AI設定を確認してください。',
+    });
+    expect(mockedGetProvider).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/ai/chat/route.ts
+++ b/src/app/api/ai/chat/route.ts
@@ -1,7 +1,12 @@
 import { NextRequest } from 'next/server';
 import { getProvider, isValidProvider } from '@/lib/ai/providers';
 import { AIContext, AIMessage, AIProviderType } from '@/types/ai';
-import { verifyAuthToken, getUserAIApiKey } from '@/lib/firebase/admin';
+import {
+  getUserAIApiKey,
+  getUserAIProjectAccessSettings,
+  verifyAuthToken,
+} from '@/lib/firebase/admin';
+import { filterProjectsForAI, isAIProjectAllowed } from '@/lib/ai/projectAccess';
 
 // Enable streaming for Vercel
 export const runtime = 'nodejs';
@@ -66,6 +71,21 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    const { allowedProjectIds } = await getUserAIProjectAccessSettings(userId);
+    if (!isAIProjectAllowed(projectId, allowedProjectIds)) {
+      return new Response(
+        JSON.stringify({ error: 'このプロジェクトではAIアクセスが無効です。AI設定を確認してください。' }),
+        { status: 403, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const filteredContext: AIContext = {
+      ...context,
+      projects: context.projects
+        ? filterProjectsForAI(context.projects, allowedProjectIds)
+        : context.projects,
+    };
+
     // Get provider and create streaming response
     const aiProvider = getProvider(provider);
 
@@ -82,7 +102,7 @@ export async function POST(request: NextRequest) {
 
         const generator = aiProvider.sendMessage(
           messages,
-          context,
+          filteredContext,
           apiKey,
           model,
           { enableTools, projectId: projectId ?? undefined }

--- a/src/app/api/ai/settings/route.test.ts
+++ b/src/app/api/ai/settings/route.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { GET, PATCH } from './route';
+
+vi.mock('@/lib/firebase/admin', () => ({
+  verifyAuthToken: vi.fn(),
+  getUserAIProjectAccessSettings: vi.fn(),
+  saveUserAIProjectAccessSettings: vi.fn(),
+}));
+
+import {
+  getUserAIProjectAccessSettings,
+  saveUserAIProjectAccessSettings,
+  verifyAuthToken,
+} from '@/lib/firebase/admin';
+
+const mockedVerifyAuthToken = vi.mocked(verifyAuthToken);
+const mockedGetUserAIProjectAccessSettings = vi.mocked(getUserAIProjectAccessSettings);
+const mockedSaveUserAIProjectAccessSettings = vi.mocked(saveUserAIProjectAccessSettings);
+
+describe('/api/ai/settings', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockedVerifyAuthToken.mockResolvedValue({ uid: 'user-1' });
+  });
+
+  it('returns allowed project ids', async () => {
+    mockedGetUserAIProjectAccessSettings.mockResolvedValue({
+      allowedProjectIds: ['project-1', 'project-2'],
+    });
+
+    const request = new NextRequest('http://localhost/api/ai/settings', {
+      method: 'GET',
+      headers: {
+        Authorization: 'Bearer firebase-id-token',
+      },
+    });
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(mockedVerifyAuthToken).toHaveBeenCalledWith('Bearer firebase-id-token');
+    await expect(response.json()).resolves.toEqual({
+      allowedProjectIds: ['project-1', 'project-2'],
+    });
+  });
+
+  it('saves an unrestricted configuration as null', async () => {
+    const request = new NextRequest('http://localhost/api/ai/settings', {
+      method: 'PATCH',
+      body: JSON.stringify({ allowedProjectIds: null }),
+      headers: {
+        Authorization: 'Bearer firebase-id-token',
+        'Content-Type': 'application/json',
+      },
+    });
+
+    const response = await PATCH(request);
+
+    expect(response.status).toBe(200);
+    expect(mockedSaveUserAIProjectAccessSettings).toHaveBeenCalledWith('user-1', null);
+    await expect(response.json()).resolves.toEqual({ allowedProjectIds: null });
+  });
+
+  it('rejects invalid payloads', async () => {
+    const request = new NextRequest('http://localhost/api/ai/settings', {
+      method: 'PATCH',
+      body: JSON.stringify({ allowedProjectIds: 'project-1' }),
+      headers: {
+        Authorization: 'Bearer firebase-id-token',
+        'Content-Type': 'application/json',
+      },
+    });
+
+    const response = await PATCH(request);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: 'allowedProjectIds must be an array or null',
+    });
+    expect(mockedSaveUserAIProjectAccessSettings).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/ai/settings/route.ts
+++ b/src/app/api/ai/settings/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  getUserAIProjectAccessSettings,
+  saveUserAIProjectAccessSettings,
+  verifyAuthToken,
+} from '@/lib/firebase/admin';
+
+export async function GET(request: NextRequest) {
+  try {
+    const user = await verifyAuthToken(request.headers.get('Authorization'));
+    const settings = await getUserAIProjectAccessSettings(user.uid);
+
+    return NextResponse.json(settings);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Internal server error';
+    return NextResponse.json({ error: message }, { status: 401 });
+  }
+}
+
+export async function PATCH(request: NextRequest) {
+  try {
+    const user = await verifyAuthToken(request.headers.get('Authorization'));
+    const body = await request.json();
+    const rawAllowedProjectIds = body?.allowedProjectIds;
+
+    if (
+      rawAllowedProjectIds !== null &&
+      rawAllowedProjectIds !== undefined &&
+      !Array.isArray(rawAllowedProjectIds)
+    ) {
+      return NextResponse.json(
+        { error: 'allowedProjectIds must be an array or null' },
+        { status: 400 }
+      );
+    }
+
+    const allowedProjectIds = Array.isArray(rawAllowedProjectIds)
+      ? rawAllowedProjectIds.filter(
+          (projectId): projectId is string =>
+            typeof projectId === 'string' && projectId.length > 0
+        )
+      : null;
+
+    await saveUserAIProjectAccessSettings(user.uid, allowedProjectIds);
+
+    return NextResponse.json({ allowedProjectIds });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Internal server error';
+    const status = message.includes('Authorization') ? 401 : 500;
+    return NextResponse.json({ error: message }, { status });
+  }
+}

--- a/src/components/ai/AISettingsForm.tsx
+++ b/src/components/ai/AISettingsForm.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Checkbox } from '@/components/ui/checkbox';
 import {
   Select,
   SelectContent,
@@ -13,6 +14,8 @@ import {
 } from '@/components/ui/select';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { useAISettings } from '@/hooks/useAISettings';
+import { useProjects } from '@/hooks/useProjects';
+import { filterProjectsForAI, normalizeAllowedProjectIdsForSave } from '@/lib/ai/projectAccess';
 import { AIProviderType } from '@/types/ai';
 import { Eye, EyeOff, CheckCircle, AlertCircle, Loader2 } from 'lucide-react';
 
@@ -21,18 +24,36 @@ export function AISettingsForm() {
     provider,
     isConfigured,
     isSaving,
+    isProjectAccessSaving,
+    projectAccessError,
+    projectAccessLoaded,
     model,
+    allowedProjectIds,
     providers,
     defaultModels,
     setProvider,
     saveApiKey,
+    saveProjectAccess,
     setModel,
   } = useAISettings();
+  const { projects, isLoading: projectsLoading } = useProjects();
 
   const [showApiKey, setShowApiKey] = useState(false);
   const [localApiKey, setLocalApiKey] = useState('');
   const [saveError, setSaveError] = useState<string | null>(null);
   const [saveSuccess, setSaveSuccess] = useState(false);
+  const [selectedProjectIds, setSelectedProjectIds] = useState<string[]>([]);
+  const [projectAccessSaveSuccess, setProjectAccessSaveSuccess] = useState(false);
+  const [projectAccessSaveError, setProjectAccessSaveError] = useState<string | null>(null);
+
+  const visibleAllowedProjectIds = useMemo(
+    () => filterProjectsForAI(projects, allowedProjectIds).map((project) => project.id),
+    [projects, allowedProjectIds]
+  );
+
+  useEffect(() => {
+    setSelectedProjectIds(visibleAllowedProjectIds);
+  }, [visibleAllowedProjectIds]);
 
   const handleProviderChange = (value: string) => {
     setProvider(value as AIProviderType);
@@ -56,6 +77,56 @@ export function AISettingsForm() {
 
   const handleResetModel = () => {
     setModel(defaultModels[provider]);
+  };
+
+  const handleToggleProject = (projectId: string) => {
+    setProjectAccessSaveSuccess(false);
+    setProjectAccessSaveError(null);
+    setSelectedProjectIds((current) =>
+      current.includes(projectId)
+        ? current.filter((id) => id !== projectId)
+        : [...current, projectId]
+    );
+  };
+
+  const handleSelectAllProjects = () => {
+    setProjectAccessSaveSuccess(false);
+    setProjectAccessSaveError(null);
+    setSelectedProjectIds(projects.map((project) => project.id));
+  };
+
+  const handleClearAllProjects = () => {
+    setProjectAccessSaveSuccess(false);
+    setProjectAccessSaveError(null);
+    setSelectedProjectIds([]);
+  };
+
+  const hasProjectAccessChanges = useMemo(() => {
+    if (selectedProjectIds.length !== visibleAllowedProjectIds.length) {
+      return true;
+    }
+
+    const selectedProjectIdSet = new Set(selectedProjectIds);
+    return visibleAllowedProjectIds.some((projectId) => !selectedProjectIdSet.has(projectId));
+  }, [selectedProjectIds, visibleAllowedProjectIds]);
+
+  const handleSaveProjectAccess = async () => {
+    setProjectAccessSaveError(null);
+    setProjectAccessSaveSuccess(false);
+
+    try {
+      const normalizedAllowedProjectIds = normalizeAllowedProjectIdsForSave(
+        selectedProjectIds,
+        projects.map((project) => project.id)
+      );
+      await saveProjectAccess(normalizedAllowedProjectIds);
+      setProjectAccessSaveSuccess(true);
+      setTimeout(() => setProjectAccessSaveSuccess(false), 3000);
+    } catch (error) {
+      setProjectAccessSaveError(
+        error instanceof Error ? error.message : 'AIアクセス設定の保存に失敗しました'
+      );
+    }
   };
 
   return (
@@ -192,6 +263,108 @@ export function AISettingsForm() {
             <p className="text-xs text-muted-foreground">
               デフォルト: {defaultModels[provider]}
             </p>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>AIアクセス対象プロジェクト</CardTitle>
+          <CardDescription>
+            AIが閲覧・操作できるプロジェクトを選択します
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex flex-wrap gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={handleSelectAllProjects}
+              disabled={projectsLoading || projects.length === 0}
+            >
+              すべて選択
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={handleClearAllProjects}
+              disabled={projectsLoading || projects.length === 0}
+            >
+              すべて解除
+            </Button>
+          </div>
+
+          {!projectAccessLoaded && !projectAccessError ? (
+            <div className="flex items-center gap-2 rounded-md bg-muted p-3 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              AIアクセス設定を読み込み中...
+            </div>
+          ) : projectsLoading ? (
+            <div className="flex items-center gap-2 rounded-md bg-muted p-3 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              プロジェクトを読み込み中...
+            </div>
+          ) : projects.length === 0 ? (
+            <div className="rounded-md bg-muted p-3 text-sm text-muted-foreground">
+              プロジェクトがありません。作成後にAIアクセス対象を選択できます。
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {projects.map((project) => (
+                <div key={project.id} className="flex items-start gap-3 rounded-md border p-3">
+                  <Checkbox
+                    id={`ai-project-${project.id}`}
+                    checked={selectedProjectIds.includes(project.id)}
+                    onCheckedChange={() => handleToggleProject(project.id)}
+                  />
+                  <div className="grid gap-0.5 leading-none">
+                    <label
+                      htmlFor={`ai-project-${project.id}`}
+                      className="cursor-pointer text-sm font-medium"
+                    >
+                      {project.name}
+                    </label>
+                    <p className="text-xs text-muted-foreground">
+                      {project.description || 'このプロジェクトでAIを利用できます'}
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {(projectAccessError || projectAccessSaveError) && (
+            <div className="flex items-center gap-2 rounded-md bg-destructive/10 p-3">
+              <AlertCircle className="h-4 w-4 text-destructive" />
+              <span className="text-sm text-destructive">
+                {projectAccessSaveError || projectAccessError}
+              </span>
+            </div>
+          )}
+
+          {projectAccessSaveSuccess && (
+            <div className="flex items-center gap-2 rounded-md bg-green-50 p-3">
+              <CheckCircle className="h-4 w-4 text-green-600" />
+              <span className="text-sm text-green-600">AIアクセス設定を保存しました</span>
+            </div>
+          )}
+
+          <div className="flex items-center justify-between rounded-md bg-muted p-3">
+            <p className="text-xs text-muted-foreground">
+              未選択のプロジェクトは相棒AIの対象外になります。
+            </p>
+            <Button
+              type="button"
+              onClick={handleSaveProjectAccess}
+              disabled={projectsLoading || isProjectAccessSaving || !hasProjectAccessChanges}
+            >
+              {isProjectAccessSaving ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : null}
+              保存
+            </Button>
           </div>
         </CardContent>
       </Card>

--- a/src/components/ai/CompanionAI.tsx
+++ b/src/components/ai/CompanionAI.tsx
@@ -26,6 +26,8 @@ import { useAISettingsStore } from '@/stores/aiSettingsStore';
 import { useUnifiedConversation } from '@/hooks/useUnifiedConversation';
 import { useCompanionState } from '@/hooks/useCompanionState';
 import { useUnifiedConversations } from '@/hooks/useUnifiedConversations';
+import { getAuthHeaders } from '@/lib/firebase/authToken';
+import { filterProjectsForAI, isAIProjectAllowed } from '@/lib/ai/projectAccess';
 import { ChatInput } from './ChatInput';
 import { ChatMessage } from './ChatMessage';
 import { ToolConfirmDialog } from './ToolConfirmDialog';
@@ -52,7 +54,14 @@ export function CompanionAI({ projectId }: CompanionAIProps) {
   const userId = user?.id || firebaseUser?.uid || '';
   const displayName = user?.displayName || firebaseUser?.displayName || '';
   const { projects, isLoading: projectsLoading } = useProjects();
-  const { provider, isConfigured } = useAISettingsStore();
+  const {
+    provider,
+    isConfigured,
+    allowedProjectIds,
+    projectAccessLoaded,
+    setAllowedProjectIds,
+    setProjectAccessLoaded,
+  } = useAISettingsStore();
   const {
     timePeriod,
     currentHour,
@@ -73,19 +82,83 @@ export function CompanionAI({ projectId }: CompanionAIProps) {
   const [showConversations, setShowConversations] = useState(false);
   const [showToolConfirm, setShowToolConfirm] = useState(false);
   const [pendingTools, setPendingTools] = useState<ToolCall[] | null>(null);
+  const [projectAccessError, setProjectAccessError] = useState<string | null>(null);
 
   const panelRef = useRef<HTMLDivElement>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const projectAccessRequestedRef = useRef(false);
+
+  useEffect(() => {
+    projectAccessRequestedRef.current = false;
+    setProjectAccessError(null);
+    setProjectAccessLoaded(false);
+  }, [firebaseUser?.uid, setProjectAccessLoaded]);
+
+  useEffect(() => {
+    if (!firebaseUser || projectAccessLoaded || projectAccessRequestedRef.current) {
+      return;
+    }
+
+    projectAccessRequestedRef.current = true;
+
+    void (async () => {
+      try {
+        setProjectAccessError(null);
+        const headers = await getAuthHeaders();
+        const response = await fetch('/api/ai/settings', { headers });
+
+        if (!response.ok) {
+          const data = await response.json().catch(() => null);
+          throw new Error(data?.error || 'AIアクセス設定の取得に失敗しました');
+        }
+
+        const data = await response.json();
+        setAllowedProjectIds(
+          Array.isArray(data.allowedProjectIds) ? data.allowedProjectIds : null
+        );
+        setProjectAccessLoaded(true);
+      } catch (error) {
+        setProjectAccessError(
+          error instanceof Error ? error.message : 'AIアクセス設定の取得に失敗しました'
+        );
+      }
+    })();
+  }, [
+    firebaseUser,
+    projectAccessLoaded,
+    setAllowedProjectIds,
+    setProjectAccessLoaded,
+  ]);
 
   // Find current project details
   const currentProject = useMemo(
     () => projects.find((p) => p.id === projectId),
     [projects, projectId]
   );
+  const accessibleProjects = useMemo(
+    () => filterProjectsForAI(projects, allowedProjectIds),
+    [projects, allowedProjectIds]
+  );
+  const isCurrentProjectAllowed = useMemo(
+    () => isAIProjectAllowed(projectId, allowedProjectIds),
+    [projectId, allowedProjectIds]
+  );
+  const projectIds = useMemo(
+    () => accessibleProjects.map((project) => project.id),
+    [accessibleProjects]
+  );
+  const isProjectAccessBlocked = Boolean(
+    projectAccessLoaded &&
+      (
+        (!projectId && projectIds.length === 0) ||
+        (projectId && !isCurrentProjectAllowed)
+      )
+  );
+  const effectiveUserId = projectAccessLoaded && !isProjectAccessBlocked ? userId : '';
 
   // Build context dynamically based on projectId
   const companionContext: AIContext = useMemo(() => {
-    if (projectId && currentProject) {
+    if (projectId && currentProject && isCurrentProjectAllowed) {
       return {
         scope: 'companion' as const,
         project: {
@@ -95,7 +168,7 @@ export function CompanionAI({ projectId }: CompanionAIProps) {
           lists: [],
           members: [],
         },
-        projects: projects.map((p) => ({
+        projects: accessibleProjects.map((p) => ({
           id: p.id,
           name: p.name,
           description: p.description || '',
@@ -111,7 +184,7 @@ export function CompanionAI({ projectId }: CompanionAIProps) {
     }
     return {
       scope: 'companion' as const,
-      projects: projects.map((p) => ({
+      projects: accessibleProjects.map((p) => ({
         id: p.id,
         name: p.name,
         description: p.description || '',
@@ -124,7 +197,15 @@ export function CompanionAI({ projectId }: CompanionAIProps) {
       },
       currentHour,
     };
-  }, [userId, displayName, projects, currentProject, projectId, currentHour]);
+  }, [
+    accessibleProjects,
+    currentHour,
+    currentProject,
+    displayName,
+    isCurrentProjectAllowed,
+    projectId,
+    userId,
+  ]);
 
   // Dynamic quick actions based on context
   const quickActions: QuickAction[] = useMemo(() => {
@@ -190,16 +271,13 @@ export function CompanionAI({ projectId }: CompanionAIProps) {
     return [reportAction, priorityAction, workloadAction, planAction];
   }, [projectId, timePeriod]);
 
-  // Project IDs for cross-project tools
-  const projectIds = useMemo(() => projects.map((p) => p.id), [projects]);
-
   // Conversations list (filtered by projectId context)
   const {
     conversations,
     isLoading: conversationsLoading,
     deleteConversationById,
   } = useUnifiedConversations({
-    userId: userId || null,
+    userId: effectiveUserId || null,
     projectId: projectId ?? null,
   });
 
@@ -213,8 +291,8 @@ export function CompanionAI({ projectId }: CompanionAIProps) {
     cancelToolExecution,
     clearMessages,
   } = useUnifiedConversation({
-    userId,
-    projectId,
+    userId: effectiveUserId,
+    projectId: isProjectAccessBlocked ? null : projectId,
     projectIds,
     context: companionContext,
     conversationId: selectedConversationId,
@@ -277,9 +355,9 @@ export function CompanionAI({ projectId }: CompanionAIProps) {
 
   // Handle sending a message
   const handleSendMessage = useCallback(async (content: string) => {
-    if (!userId) return;
+    if (!effectiveUserId || isProjectAccessBlocked || !projectAccessLoaded) return;
     await sendMessage(content);
-  }, [userId, sendMessage]);
+  }, [effectiveUserId, isProjectAccessBlocked, projectAccessLoaded, sendMessage]);
 
   // Handle quick action
   const handleQuickAction = useCallback((action: QuickAction) => {
@@ -341,7 +419,31 @@ export function CompanionAI({ projectId }: CompanionAIProps) {
   }, [projectId, currentProject, timePeriod]);
 
   // Disable check - need either projects (dashboard) or projectId (project page)
-  const isDisabled = !projectId && projectIds.length === 0;
+  const isProjectAccessLoading = !projectAccessLoaded && !projectAccessError;
+  const isDisabled =
+    isProjectAccessLoading ||
+    isProjectAccessBlocked ||
+    (!projectId && projectIds.length === 0);
+  const accessStateCopy = useMemo(() => {
+    if (projectAccessError) {
+      return {
+        title: 'AIアクセス設定を読み込めませんでした',
+        description: projectAccessError,
+      };
+    }
+
+    if (projectId && !isCurrentProjectAllowed) {
+      return {
+        title: 'このプロジェクトではAIアクセスが無効です',
+        description: 'AI設定でこのプロジェクトを有効にすると、相棒AIが再び利用できます。',
+      };
+    }
+
+    return {
+      title: 'AIアクセス対象のプロジェクトがありません',
+      description: 'AI設定で少なくとも1つのプロジェクトを有効にしてください。',
+    };
+  }, [isCurrentProjectAllowed, projectAccessError, projectId]);
 
   // Auto-greeting on panel open (dashboard only)
   const autoGreetSentRef = useRef(false);
@@ -352,7 +454,9 @@ export function CompanionAI({ projectId }: CompanionAIProps) {
       messages.length === 0 &&
       !selectedConversationId &&
       isApiConfigured &&
+      projectAccessLoaded &&
       projectIds.length > 0 &&
+      !isProjectAccessBlocked &&
       !autoGreetSentRef.current
     ) {
       if (shouldShowMorningGreeting) {
@@ -374,7 +478,21 @@ export function CompanionAI({ projectId }: CompanionAIProps) {
     if (!isOpen || selectedConversationId) {
       autoGreetSentRef.current = false;
     }
-  }, [isOpen, projectId, messages.length, selectedConversationId, isApiConfigured, projectIds.length, shouldShowMorningGreeting, shouldShowEveningReport, markMorningGreeted, markEveningReported, sendMessage]);
+  }, [
+    isApiConfigured,
+    isOpen,
+    isProjectAccessBlocked,
+    markEveningReported,
+    markMorningGreeted,
+    messages.length,
+    projectAccessLoaded,
+    projectId,
+    projectIds.length,
+    selectedConversationId,
+    sendMessage,
+    shouldShowEveningReport,
+    shouldShowMorningGreeting,
+  ]);
 
   if (!firebaseUser) return null;
 
@@ -454,6 +572,30 @@ export function CompanionAI({ projectId }: CompanionAIProps) {
                 <h3 className="font-medium">APIキーが設定されていません</h3>
                 <p className="mt-1 text-sm text-muted-foreground">
                   AI機能を使用するには、設定画面でAPIキーを設定してください。
+                </p>
+              </div>
+              <Button onClick={handleGoToSettings}>
+                <Settings className="mr-2 h-4 w-4" />
+                設定画面へ
+              </Button>
+            </div>
+          ) : isProjectAccessLoading ? (
+            <div className="flex flex-1 flex-col items-center justify-center gap-4 p-8">
+              <Loader2 className="h-12 w-12 animate-spin text-muted-foreground" />
+              <div className="text-center">
+                <h3 className="font-medium">AIアクセス設定を読み込み中です</h3>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  プロジェクトごとのAI利用設定を確認しています。
+                </p>
+              </div>
+            </div>
+          ) : projectAccessError || isProjectAccessBlocked ? (
+            <div className="flex flex-1 flex-col items-center justify-center gap-4 p-8">
+              <AlertCircle className="h-12 w-12 text-muted-foreground" />
+              <div className="text-center">
+                <h3 className="font-medium">{accessStateCopy.title}</h3>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  {accessStateCopy.description}
                 </p>
               </div>
               <Button onClick={handleGoToSettings}>

--- a/src/hooks/useAISettings.ts
+++ b/src/hooks/useAISettings.ts
@@ -10,19 +10,27 @@ interface UseAISettingsReturn {
   provider: AIProviderType;
   isConfigured: boolean;
   isSaving: boolean;
+  isProjectAccessSaving: boolean;
+  projectAccessError: string | null;
+  projectAccessLoaded: boolean;
   model: string;
+  allowedProjectIds: string[] | null;
   providers: Array<{ value: AIProviderType; label: string }>;
   defaultModels: Record<AIProviderType, string>;
   setProvider: (provider: AIProviderType) => void;
   saveApiKey: (apiKey: string) => Promise<void>;
+  saveProjectAccess: (allowedProjectIds: string[] | null) => Promise<void>;
   setModel: (model: string) => void;
   refreshKeyStatus: () => Promise<void>;
+  refreshProjectAccess: () => Promise<void>;
 }
 
 export function useAISettings(): UseAISettingsReturn {
   const store = useAISettingsStore();
   const { isAuthenticated } = useAuthStore();
   const [isSaving, setIsSaving] = useState(false);
+  const [isProjectAccessSaving, setIsProjectAccessSaving] = useState(false);
+  const [projectAccessError, setProjectAccessError] = useState<string | null>(null);
 
   const providers = Object.entries(PROVIDER_DISPLAY_NAMES).map(([value, label]) => ({
     value: value as AIProviderType,
@@ -48,9 +56,36 @@ export function useAISettings(): UseAISettingsReturn {
     }
   }, [isAuthenticated, store]);
 
+  const refreshProjectAccess = useCallback(async () => {
+    if (!isAuthenticated) return;
+
+    try {
+      setProjectAccessError(null);
+      const headers = await getAuthHeaders();
+      const response = await fetch('/api/ai/settings', { headers });
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => null);
+        throw new Error(data?.error || 'AIアクセス設定の取得に失敗しました');
+      }
+
+      const data = await response.json();
+      store.setAllowedProjectIds(
+        Array.isArray(data.allowedProjectIds) ? data.allowedProjectIds : null
+      );
+      store.setProjectAccessLoaded(true);
+    } catch (error) {
+      store.setProjectAccessLoaded(false);
+      setProjectAccessError(
+        error instanceof Error ? error.message : 'AIアクセス設定の取得に失敗しました'
+      );
+    }
+  }, [isAuthenticated, store]);
+
   useEffect(() => {
     refreshKeyStatus();
-  }, [refreshKeyStatus]);
+    refreshProjectAccess();
+  }, [refreshKeyStatus, refreshProjectAccess]);
 
   // Save API key to server
   const saveApiKey = useCallback(async (apiKey: string) => {
@@ -74,16 +109,53 @@ export function useAISettings(): UseAISettingsReturn {
     }
   }, [store]);
 
+  const saveProjectAccess = useCallback(async (allowedProjectIds: string[] | null) => {
+    setIsProjectAccessSaving(true);
+    setProjectAccessError(null);
+    try {
+      const headers = await getAuthHeaders();
+      const response = await fetch('/api/ai/settings', {
+        method: 'PATCH',
+        headers,
+        body: JSON.stringify({ allowedProjectIds }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => null);
+        throw new Error(data?.error || 'AIアクセス設定の保存に失敗しました');
+      }
+
+      const data = await response.json();
+      store.setAllowedProjectIds(
+        Array.isArray(data.allowedProjectIds) ? data.allowedProjectIds : null
+      );
+      store.setProjectAccessLoaded(true);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'AIアクセス設定の保存に失敗しました';
+      setProjectAccessError(message);
+      throw error;
+    } finally {
+      setIsProjectAccessSaving(false);
+    }
+  }, [store]);
+
   return {
     provider: store.provider,
     isConfigured: store.isConfigured(),
     isSaving,
+    isProjectAccessSaving,
+    projectAccessError,
+    projectAccessLoaded: store.projectAccessLoaded,
     model: store.getActiveModel(),
+    allowedProjectIds: store.allowedProjectIds,
     providers,
     defaultModels: DEFAULT_MODELS,
     setProvider: store.setProvider,
     saveApiKey,
+    saveProjectAccess,
     setModel: (model: string) => store.setModel(store.provider, model),
     refreshKeyStatus,
+    refreshProjectAccess,
   };
 }

--- a/src/lib/ai/projectAccess.test.ts
+++ b/src/lib/ai/projectAccess.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import {
+  filterProjectsForAI,
+  isAIProjectAllowed,
+  normalizeAllowedProjectIdsForSave,
+} from './projectAccess';
+
+describe('AI project access helpers', () => {
+  const projects = [
+    { id: 'project-1', name: 'One' },
+    { id: 'project-2', name: 'Two' },
+    { id: 'project-3', name: 'Three' },
+  ];
+
+  describe('filterProjectsForAI', () => {
+    it('returns all projects when access is unrestricted', () => {
+      expect(filterProjectsForAI(projects, null)).toEqual(projects);
+    });
+
+    it('filters projects to the configured subset', () => {
+      expect(filterProjectsForAI(projects, ['project-2'])).toEqual([
+        { id: 'project-2', name: 'Two' },
+      ]);
+    });
+  });
+
+  describe('isAIProjectAllowed', () => {
+    it('allows any project when access is unrestricted', () => {
+      expect(isAIProjectAllowed('project-1', null)).toBe(true);
+    });
+
+    it('rejects projects outside the configured subset', () => {
+      expect(isAIProjectAllowed('project-3', ['project-1', 'project-2'])).toBe(false);
+    });
+  });
+
+  describe('normalizeAllowedProjectIdsForSave', () => {
+    it('stores null when every current project is selected', () => {
+      expect(
+        normalizeAllowedProjectIdsForSave(
+          ['project-1', 'project-2', 'project-3'],
+          ['project-1', 'project-2', 'project-3']
+        )
+      ).toBeNull();
+    });
+
+    it('stores only selected projects when the selection is restricted', () => {
+      expect(
+        normalizeAllowedProjectIdsForSave(
+          ['project-1', 'project-3'],
+          ['project-1', 'project-2', 'project-3']
+        )
+      ).toEqual(['project-1', 'project-3']);
+    });
+  });
+});

--- a/src/lib/ai/projectAccess.ts
+++ b/src/lib/ai/projectAccess.ts
@@ -1,0 +1,40 @@
+export function filterProjectsForAI<T extends { id: string }>(
+  projects: T[],
+  allowedProjectIds: string[] | null
+): T[] {
+  if (allowedProjectIds === null) {
+    return projects;
+  }
+
+  const allowedProjectIdSet = new Set(allowedProjectIds);
+  return projects.filter((project) => allowedProjectIdSet.has(project.id));
+}
+
+export function isAIProjectAllowed(
+  projectId: string | null | undefined,
+  allowedProjectIds: string[] | null
+): boolean {
+  if (!projectId) {
+    return true;
+  }
+
+  return allowedProjectIds === null || allowedProjectIds.includes(projectId);
+}
+
+export function normalizeAllowedProjectIdsForSave(
+  selectedProjectIds: string[],
+  allProjectIds: string[]
+): string[] | null {
+  const allProjectIdSet = new Set(allProjectIds);
+  const normalizedSelectedProjectIds = Array.from(new Set(selectedProjectIds))
+    .filter((projectId) => allProjectIdSet.has(projectId));
+
+  if (
+    normalizedSelectedProjectIds.length === allProjectIds.length &&
+    allProjectIds.every((projectId) => normalizedSelectedProjectIds.includes(projectId))
+  ) {
+    return null;
+  }
+
+  return normalizedSelectedProjectIds;
+}

--- a/src/lib/firebase/admin.ts
+++ b/src/lib/firebase/admin.ts
@@ -107,3 +107,44 @@ export async function getUserAISettings(userId: string): Promise<Record<string, 
 
   return settingsDoc.data() as Record<string, string>;
 }
+
+export interface UserAIProjectAccessSettings {
+  allowedProjectIds: string[] | null;
+}
+
+/**
+ * Get AI project access settings for a user from Firestore.
+ * Null means AI can access all current and future projects.
+ */
+export async function getUserAIProjectAccessSettings(
+  userId: string
+): Promise<UserAIProjectAccessSettings> {
+  const db = getAdminDb();
+  const settingsDoc = await db.collection('users').doc(userId).collection('settings').doc('aiSettings').get();
+
+  if (!settingsDoc.exists) {
+    return { allowedProjectIds: null };
+  }
+
+  const data = settingsDoc.data();
+  const allowedProjectIds = Array.isArray(data?.allowedProjectIds)
+    ? data.allowedProjectIds.filter((projectId): projectId is string => typeof projectId === 'string' && projectId.length > 0)
+    : null;
+
+  return { allowedProjectIds };
+}
+
+/**
+ * Save AI project access settings for a user to Firestore.
+ * Null means AI can access all current and future projects.
+ */
+export async function saveUserAIProjectAccessSettings(
+  userId: string,
+  allowedProjectIds: string[] | null
+): Promise<void> {
+  const db = getAdminDb();
+  await db.collection('users').doc(userId).collection('settings').doc('aiSettings').set(
+    { allowedProjectIds },
+    { merge: true }
+  );
+}

--- a/src/stores/aiSettingsStore.test.ts
+++ b/src/stores/aiSettingsStore.test.ts
@@ -8,6 +8,8 @@ describe('aiSettingsStore', () => {
       openaiKeyConfigured: false,
       anthropicKeyConfigured: false,
       geminiKeyConfigured: false,
+      allowedProjectIds: null,
+      projectAccessLoaded: false,
       openaiModel: 'gpt-4o',
       anthropicModel: 'claude-sonnet-4-20250514',
       geminiModel: 'gemini-3-flash-preview',
@@ -58,6 +60,26 @@ describe('aiSettingsStore', () => {
     it('should change gemini model', () => {
       useAISettingsStore.getState().setModel('gemini', 'gemini-pro');
       expect(useAISettingsStore.getState().geminiModel).toBe('gemini-pro');
+    });
+  });
+
+  describe('project access', () => {
+    it('should store restricted project ids', () => {
+      useAISettingsStore.getState().setAllowedProjectIds(['project-1']);
+      useAISettingsStore.getState().setProjectAccessLoaded(true);
+
+      expect(useAISettingsStore.getState().allowedProjectIds).toEqual(['project-1']);
+      expect(useAISettingsStore.getState().projectAccessLoaded).toBe(true);
+    });
+
+    it('should allow every project when access is unrestricted', () => {
+      expect(useAISettingsStore.getState().canAccessProject('project-1')).toBe(true);
+    });
+
+    it('should block projects outside the restricted set', () => {
+      useAISettingsStore.getState().setAllowedProjectIds(['project-2']);
+      expect(useAISettingsStore.getState().canAccessProject('project-1')).toBe(false);
+      expect(useAISettingsStore.getState().canAccessProject('project-2')).toBe(true);
     });
   });
 

--- a/src/stores/aiSettingsStore.ts
+++ b/src/stores/aiSettingsStore.ts
@@ -9,6 +9,9 @@ interface AISettingsState {
   openaiKeyConfigured: boolean;
   anthropicKeyConfigured: boolean;
   geminiKeyConfigured: boolean;
+  // Project access scope. Null means all projects are allowed.
+  allowedProjectIds: string[] | null;
+  projectAccessLoaded: boolean;
   // Models
   openaiModel: string;
   anthropicModel: string;
@@ -16,9 +19,12 @@ interface AISettingsState {
   // Actions
   setProvider: (provider: AIProviderType) => void;
   setKeyConfigured: (provider: AIProviderType, configured: boolean) => void;
+  setAllowedProjectIds: (projectIds: string[] | null) => void;
+  setProjectAccessLoaded: (loaded: boolean) => void;
   setModel: (provider: AIProviderType, model: string) => void;
   getActiveModel: () => string;
   isConfigured: () => boolean;
+  canAccessProject: (projectId: string | null | undefined) => boolean;
 }
 
 export const useAISettingsStore = create<AISettingsState>()(
@@ -28,6 +34,8 @@ export const useAISettingsStore = create<AISettingsState>()(
       openaiKeyConfigured: false,
       anthropicKeyConfigured: false,
       geminiKeyConfigured: false,
+      allowedProjectIds: null,
+      projectAccessLoaded: false,
       openaiModel: DEFAULT_MODELS.openai,
       anthropicModel: DEFAULT_MODELS.anthropic,
       geminiModel: DEFAULT_MODELS.gemini,
@@ -47,6 +55,9 @@ export const useAISettingsStore = create<AISettingsState>()(
             break;
         }
       },
+
+      setAllowedProjectIds: (allowedProjectIds) => set({ allowedProjectIds }),
+      setProjectAccessLoaded: (projectAccessLoaded) => set({ projectAccessLoaded }),
 
       setModel: (provider, model) => {
         switch (provider) {
@@ -84,6 +95,14 @@ export const useAISettingsStore = create<AISettingsState>()(
           case 'gemini':
             return state.geminiKeyConfigured;
         }
+      },
+
+      canAccessProject: (projectId) => {
+        const state = get();
+        if (!projectId) {
+          return true;
+        }
+        return state.allowedProjectIds === null || state.allowedProjectIds.includes(projectId);
       },
     }),
     {


### PR DESCRIPTION
## Summary
- add first-party AI settings routes for per-project access control
- add AI settings checkboxes to choose which projects Companion AI can access
- enforce the restriction in Companion AI and the chat API, and document the behavior

## Testing
- npm run audit
- npm run lint
- npm run test:run
- npm run build
- npm run test:e2e:smoke

Closes #29
