### PR TITLE
Make API key creation dialog scrollable

### DIFF
--- a/src/app/(dashboard)/settings/api-keys/page.tsx
+++ b/src/app/(dashboard)/settings/api-keys/page.tsx
@@ -352,7 +352,7 @@ export default function ApiKeysPage() {
                   新規作成
                 </Button>
               </DialogTrigger>
-              <DialogContent className="sm:max-w-lg">
+              <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
                 {newPlainTextKey ? (
                   <>
                     <DialogHeader>


### PR DESCRIPTION
## Summary
- cap the API key creation dialog height
- enable vertical scrolling when project scope checkboxes make the dialog taller than the viewport

## Testing
- npm run audit
- npm run lint
- npm run test:run
- npm run build
- npm run test:e2e:smoke

Closes #33
