### PR TITLE
Add display name and icon metadata to API tokens

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -29,11 +29,16 @@ Request body:
 ```json
 {
   "name": "Claude Desktop",
+  "actorDisplayName": "Codex",
+  "actorIcon": "🤖",
   "permissions": ["projects:read", "tasks:read", "tasks:write"],
   "projectIds": null,
   "expiresAt": null
 }
 ```
+
+`name` is the management label for the token itself.
+`actorDisplayName` and `actorIcon` are optional audit-facing metadata used when TaskFlow shows actions performed via that token.
 
 ### `PATCH /api/auth/tokens/[tokenId]`
 
@@ -155,6 +160,11 @@ Supports:
 
 - content
 - mentions
+
+If the request is authenticated with a personal access token, TaskFlow may also persist audit-facing author metadata such as:
+
+- `authorLabel` like `Naofumi via Codex`
+- `authorIcon` like `🤖`
 
 Notes:
 

--- a/src/app/(dashboard)/settings/api-keys/page.tsx
+++ b/src/app/(dashboard)/settings/api-keys/page.tsx
@@ -40,6 +40,8 @@ import { normalizeAllowedProjectIdsForSave } from '@/lib/ai/projectAccess';
 import type { ApiKey, ApiKeyPermission, ApiKeyCreateData } from '@/types/apiKey';
 import { PERMISSION_GROUPS } from '@/types/apiKey';
 
+const ACTOR_ICON_PRESETS = ['🤖', '🧠', '🛠️', '💬', '⚙️'];
+
 export default function ApiKeysPage() {
   const { user, firebaseUser } = useAuth();
   const { projects, isLoading: projectsLoading } = useProjects();
@@ -48,6 +50,8 @@ export default function ApiKeysPage() {
   const [loadError, setLoadError] = useState<string | null>(null);
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const [newKeyName, setNewKeyName] = useState('');
+  const [newActorDisplayName, setNewActorDisplayName] = useState('');
+  const [newActorIcon, setNewActorIcon] = useState('🤖');
   const [selectedPermissions, setSelectedPermissions] = useState<ApiKeyPermission[]>(['tasks:read']);
   const [isCreating, setIsCreating] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
@@ -144,6 +148,8 @@ export default function ApiKeysPage() {
     try {
       const data: ApiKeyCreateData = {
         name: newKeyName.trim(),
+        actorDisplayName: newActorDisplayName.trim() || null,
+        actorIcon: newActorIcon.trim() || null,
         permissions: selectedPermissions,
         projectIds: normalizeAllowedProjectIdsForSave(
           selectedProjectIds,
@@ -194,6 +200,8 @@ export default function ApiKeysPage() {
   const handleCloseCreateDialog = () => {
     setIsCreateDialogOpen(false);
     setNewKeyName('');
+    setNewActorDisplayName('');
+    setNewActorIcon('🤖');
     setSelectedPermissions(['tasks:read']);
     setSelectedProjectIds([]);
     setHasInitializedProjectScope(false);
@@ -400,13 +408,53 @@ export default function ApiKeysPage() {
                     </DialogHeader>
                     <div className="min-h-0 space-y-4 overflow-y-auto px-6 py-4">
                       <div className="space-y-2">
-                        <Label htmlFor="key-name">キー名</Label>
+                        <Label htmlFor="key-name">管理名</Label>
                         <Input
                           id="key-name"
                           placeholder="例: Claude Desktop用"
                           value={newKeyName}
                           onChange={(e) => setNewKeyName(e.target.value)}
                         />
+                        <p className="text-xs text-muted-foreground">
+                          APIキー一覧で見分けるための内部名です。
+                        </p>
+                      </div>
+                      <div className="space-y-2">
+                        <Label htmlFor="actor-display-name">表示名</Label>
+                        <Input
+                          id="actor-display-name"
+                          placeholder="例: Codex"
+                          value={newActorDisplayName}
+                          onChange={(e) => setNewActorDisplayName(e.target.value)}
+                        />
+                        <p className="text-xs text-muted-foreground">
+                          コメントや監査表示では `ユーザー名 via 表示名` として表示されます。未設定時は管理名を使います。
+                        </p>
+                      </div>
+                      <div className="space-y-2">
+                        <Label htmlFor="actor-icon">アイコン</Label>
+                        <div className="flex gap-2">
+                          <Input
+                            id="actor-icon"
+                            className="w-20 text-center text-xl"
+                            placeholder="🤖"
+                            value={newActorIcon}
+                            onChange={(e) => setNewActorIcon(e.target.value)}
+                          />
+                          <div className="flex flex-wrap gap-2">
+                            {ACTOR_ICON_PRESETS.map((icon) => (
+                              <Button
+                                key={icon}
+                                type="button"
+                                variant={newActorIcon === icon ? 'default' : 'outline'}
+                                size="sm"
+                                onClick={() => setNewActorIcon(icon)}
+                              >
+                                {icon}
+                              </Button>
+                            ))}
+                          </div>
+                        </div>
                       </div>
                       <div className="space-y-3">
                         <Label>権限</Label>
@@ -565,6 +613,10 @@ export default function ApiKeysPage() {
                         {!key.isActive && (
                           <Badge variant="secondary">無効</Badge>
                         )}
+                      </div>
+                      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                        <span>{key.actorIcon || '🤖'}</span>
+                        <span>{key.actorDisplayName || key.name}</span>
                       </div>
                       <div className="flex items-center gap-2">
                         <code className="text-sm text-muted-foreground font-mono">

--- a/src/app/api/auth/tokens/route.test.ts
+++ b/src/app/api/auth/tokens/route.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { GET, POST } from './route';
+
+vi.mock('@/lib/firebase/admin', () => ({
+  verifyAuthToken: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/apiTokens', () => ({
+  createApiToken: vi.fn(),
+  listApiTokens: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/apiTokenErrors', () => ({
+  getApiTokenRouteError: vi.fn(() => ({ message: 'Internal server error', status: 500 })),
+}));
+
+import { verifyAuthToken } from '@/lib/firebase/admin';
+import { createApiToken, listApiTokens } from '@/lib/auth/apiTokens';
+
+const mockedVerifyAuthToken = vi.mocked(verifyAuthToken);
+const mockedCreateApiToken = vi.mocked(createApiToken);
+const mockedListApiTokens = vi.mocked(listApiTokens);
+
+describe('/api/auth/tokens', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockedVerifyAuthToken.mockResolvedValue({ uid: 'user-1' });
+  });
+
+  it('creates a token with actor metadata', async () => {
+    mockedCreateApiToken.mockResolvedValue({
+      apiKey: {
+        id: 'token-1',
+        userId: 'user-1',
+        name: 'Claude Desktop',
+        actorDisplayName: 'Codex',
+        actorIcon: '🤖',
+        keyPrefix: 'tf_example...',
+        keyHash: 'hash',
+        permissions: ['tasks:read'],
+        projectIds: null,
+        createdAt: new Date('2026-03-13T00:00:00.000Z'),
+        lastUsedAt: null,
+        expiresAt: null,
+        isActive: true,
+      },
+      plainTextKey: 'tf_example_plain_text',
+    });
+
+    const request = new NextRequest('http://localhost/api/auth/tokens', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer firebase-id-token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        name: 'Claude Desktop',
+        actorDisplayName: 'Codex',
+        actorIcon: '🤖',
+        permissions: ['tasks:read'],
+        projectIds: null,
+        expiresAt: null,
+      }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(201);
+    expect(mockedCreateApiToken).toHaveBeenCalledWith('user-1', {
+      name: 'Claude Desktop',
+      actorDisplayName: 'Codex',
+      actorIcon: '🤖',
+      permissions: ['tasks:read'],
+      projectIds: null,
+      expiresAt: null,
+    });
+    await expect(response.json()).resolves.toEqual({
+      apiKey: {
+        id: 'token-1',
+        userId: 'user-1',
+        name: 'Claude Desktop',
+        actorDisplayName: 'Codex',
+        actorIcon: '🤖',
+        keyPrefix: 'tf_example...',
+        keyHash: '',
+        permissions: ['tasks:read'],
+        projectIds: null,
+        createdAt: '2026-03-13T00:00:00.000Z',
+        lastUsedAt: null,
+        expiresAt: null,
+        isActive: true,
+      },
+      plainTextKey: 'tf_example_plain_text',
+    });
+  });
+
+  it('lists token actor metadata', async () => {
+    mockedListApiTokens.mockResolvedValue([
+      {
+        id: 'token-1',
+        userId: 'user-1',
+        name: 'Claude Desktop',
+        actorDisplayName: 'Codex',
+        actorIcon: '🤖',
+        keyPrefix: 'tf_example...',
+        keyHash: 'hash',
+        permissions: ['tasks:read'],
+        projectIds: ['project-1'],
+        createdAt: new Date('2026-03-13T00:00:00.000Z'),
+        lastUsedAt: null,
+        expiresAt: null,
+        isActive: true,
+      },
+    ]);
+
+    const request = new NextRequest('http://localhost/api/auth/tokens', {
+      method: 'GET',
+      headers: {
+        Authorization: 'Bearer firebase-id-token',
+      },
+    });
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      apiKeys: [
+        {
+          id: 'token-1',
+          userId: 'user-1',
+          name: 'Claude Desktop',
+          actorDisplayName: 'Codex',
+          actorIcon: '🤖',
+          keyPrefix: 'tf_example...',
+          keyHash: '',
+          permissions: ['tasks:read'],
+          projectIds: ['project-1'],
+          createdAt: '2026-03-13T00:00:00.000Z',
+          lastUsedAt: null,
+          expiresAt: null,
+          isActive: true,
+        },
+      ],
+    });
+  });
+});

--- a/src/app/api/auth/tokens/route.ts
+++ b/src/app/api/auth/tokens/route.ts
@@ -43,6 +43,22 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Name is required' }, { status: 400 });
     }
 
+    const actorDisplayName =
+      typeof body.actorDisplayName === 'string' && body.actorDisplayName.trim()
+        ? body.actorDisplayName.trim()
+        : null;
+    if (actorDisplayName && actorDisplayName.length > 60) {
+      return NextResponse.json({ error: 'actorDisplayName must be 60 characters or fewer' }, { status: 400 });
+    }
+
+    const actorIcon =
+      typeof body.actorIcon === 'string' && body.actorIcon.trim()
+        ? body.actorIcon.trim()
+        : null;
+    if (actorIcon && actorIcon.length > 8) {
+      return NextResponse.json({ error: 'actorIcon must be 8 characters or fewer' }, { status: 400 });
+    }
+
     const permissions = Array.isArray(body.permissions)
       ? body.permissions.filter((permission): permission is ApiKeyPermission => typeof permission === 'string' && isApiKeyPermission(permission))
       : [];
@@ -66,6 +82,8 @@ export async function POST(request: NextRequest) {
 
     const { apiKey, plainTextKey } = await createApiToken(user.uid, {
       name,
+      actorDisplayName,
+      actorIcon,
       permissions,
       projectIds,
       expiresAt,

--- a/src/app/api/projects/[projectId]/tasks/[taskId]/comments/route.test.ts
+++ b/src/app/api/projects/[projectId]/tasks/[taskId]/comments/route.test.ts
@@ -14,13 +14,19 @@ vi.mock('@/lib/firebase/admin-projects', () => ({
   createProjectTaskComment: vi.fn(),
 }));
 
+vi.mock('@/lib/firebase/admin', () => ({
+  getUserProfileSummary: vi.fn(),
+}));
+
 import { authenticateRequest } from '@/lib/auth/authenticateRequest';
 import { getProjectAccess } from '@/lib/auth/projectAccess';
 import { createProjectTaskComment } from '@/lib/firebase/admin-projects';
+import { getUserProfileSummary } from '@/lib/firebase/admin';
 
 const mockedAuthenticateRequest = vi.mocked(authenticateRequest);
 const mockedGetProjectAccess = vi.mocked(getProjectAccess);
 const mockedCreateProjectTaskComment = vi.mocked(createProjectTaskComment);
+const mockedGetUserProfileSummary = vi.mocked(getUserProfileSummary);
 
 describe('POST /api/projects/[projectId]/tasks/[taskId]/comments', () => {
   beforeEach(() => {
@@ -28,11 +34,18 @@ describe('POST /api/projects/[projectId]/tasks/[taskId]/comments', () => {
     mockedAuthenticateRequest.mockResolvedValue({
       userId: 'user-1',
       authType: 'api-token',
+      tokenName: 'Claude Desktop',
+      actorDisplayName: 'Codex',
+      actorIcon: '🤖',
       permissions: ['tasks:write'],
       projectIds: null,
       tokenId: 'token-1',
     });
     mockedGetProjectAccess.mockResolvedValue({ role: 'editor' });
+    mockedGetUserProfileSummary.mockResolvedValue({
+      displayName: 'Naofumi',
+      photoURL: null,
+    });
   });
 
   it('creates a task comment', async () => {
@@ -42,6 +55,8 @@ describe('POST /api/projects/[projectId]/tasks/[taskId]/comments', () => {
         taskId: 'task-1',
         content: 'AI progress update',
         authorId: 'user-1',
+        authorLabel: 'Naofumi via Codex',
+        authorIcon: '🤖',
         mentions: [],
         attachments: [],
         createdAt: '2026-03-13T00:00:00.000Z',
@@ -67,6 +82,8 @@ describe('POST /api/projects/[projectId]/tasks/[taskId]/comments', () => {
     expect(mockedGetProjectAccess).toHaveBeenCalledWith('user-1', 'project-1', ['tasks:write'], null, 'tasks:write');
     expect(mockedCreateProjectTaskComment).toHaveBeenCalledWith('project-1', 'task-1', 'user-1', {
       content: 'AI progress update',
+      authorLabel: 'Naofumi via Codex',
+      authorIcon: '🤖',
       mentions: undefined,
     });
     await expect(response.json()).resolves.toEqual({
@@ -75,6 +92,8 @@ describe('POST /api/projects/[projectId]/tasks/[taskId]/comments', () => {
         taskId: 'task-1',
         content: 'AI progress update',
         authorId: 'user-1',
+        authorLabel: 'Naofumi via Codex',
+        authorIcon: '🤖',
         mentions: [],
         attachments: [],
         createdAt: '2026-03-13T00:00:00.000Z',

--- a/src/app/api/projects/[projectId]/tasks/[taskId]/comments/route.ts
+++ b/src/app/api/projects/[projectId]/tasks/[taskId]/comments/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { authenticateRequest } from '@/lib/auth/authenticateRequest';
 import { getProjectAccess } from '@/lib/auth/projectAccess';
 import { createProjectTaskComment } from '@/lib/firebase/admin-projects';
+import { getUserProfileSummary } from '@/lib/firebase/admin';
 
 interface RouteContext {
   params: Promise<{
@@ -58,7 +59,23 @@ export async function POST(request: NextRequest, context: RouteContext) {
 
     const body = await request.json();
     const commentInput = parseCreateCommentBody(body);
-    const result = await createProjectTaskComment(projectId, taskId, auth.userId, commentInput);
+    let authorLabel: string | undefined;
+    let authorIcon: string | null | undefined;
+
+    if (auth.authType === 'api-token') {
+      const profile = await getUserProfileSummary(auth.userId);
+      const actorName = auth.actorDisplayName || auth.tokenName || 'API Token';
+      authorLabel = profile.displayName
+        ? `${profile.displayName} via ${actorName}`
+        : actorName;
+      authorIcon = auth.actorIcon;
+    }
+
+    const result = await createProjectTaskComment(projectId, taskId, auth.userId, {
+      ...commentInput,
+      authorLabel,
+      authorIcon,
+    });
     return NextResponse.json(result, { status: 201 });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Internal server error';

--- a/src/components/task/CommentSection.tsx
+++ b/src/components/task/CommentSection.tsx
@@ -70,13 +70,13 @@ export function CommentSection({
             <div key={comment.id} className="flex gap-3">
               <Avatar className="h-8 w-8">
                 <AvatarFallback>
-                  {comment.authorId.slice(0, 2).toUpperCase()}
+                  {comment.authorIcon || comment.authorId.slice(0, 2).toUpperCase()}
                 </AvatarFallback>
               </Avatar>
               <div className="flex-1 space-y-1">
                 <div className="flex items-center gap-2">
                   <span className="text-sm font-medium">
-                    {comment.authorId}
+                    {comment.authorLabel || comment.authorId}
                   </span>
                   <span className="text-xs text-muted-foreground">
                     {format(comment.createdAt, 'M/d HH:mm', { locale: ja })}

--- a/src/components/task/TaskDetailModal.tsx
+++ b/src/components/task/TaskDetailModal.tsx
@@ -1119,14 +1119,17 @@ export function TaskDetailModal({
                   <div className="mb-4 space-y-3">
                     {comments.map((comment) => {
                       const author = commentAuthors[comment.authorId];
-                      const authorName = author?.displayName || 'Unknown';
+                      const authorName = comment.authorLabel || author?.displayName || 'Unknown';
                       const authorInitials = authorName.slice(0, 2).toUpperCase();
+                      const authorAvatarText = comment.authorIcon || authorInitials;
                       const isEditing = editingCommentId === comment.id;
                       const isEdited = comment.updatedAt && comment.updatedAt.getTime() !== comment.createdAt.getTime();
                       return (
                         <div key={comment.id} className="group flex gap-3">
                           <div className="h-8 w-8 flex-shrink-0 rounded-full bg-muted flex items-center justify-center text-xs font-medium overflow-hidden">
-                            {author?.photoURL ? (
+                            {comment.authorIcon ? (
+                              <span className="text-sm">{authorAvatarText}</span>
+                            ) : author?.photoURL ? (
                               <Image
                                 src={author.photoURL}
                                 alt={authorName}
@@ -1135,7 +1138,7 @@ export function TaskDetailModal({
                                 className="h-full w-full object-cover"
                               />
                             ) : (
-                              authorInitials
+                              authorAvatarText
                             )}
                           </div>
                           <div className="min-w-0 flex-1">

--- a/src/lib/auth/apiTokens.ts
+++ b/src/lib/auth/apiTokens.ts
@@ -4,6 +4,8 @@ import type { ApiKey, ApiKeyCreateData, ApiKeyPermission } from '@/types/apiKey'
 
 interface ApiTokenDoc {
   name: string;
+  actorDisplayName: string | null;
+  actorIcon: string | null;
   keyPrefix: string;
   keyHash: string;
   permissions: ApiKeyPermission[];
@@ -17,6 +19,9 @@ interface ApiTokenDoc {
 export interface AuthenticatedApiToken {
   id: string;
   userId: string;
+  name: string;
+  actorDisplayName: string | null;
+  actorIcon: string | null;
   permissions: ApiKeyPermission[];
   projectIds: string[] | null;
 }
@@ -45,6 +50,8 @@ function mapApiKey(
     id,
     userId,
     name: data.name,
+    actorDisplayName: typeof data.actorDisplayName === 'string' ? data.actorDisplayName : null,
+    actorIcon: typeof data.actorIcon === 'string' ? data.actorIcon : null,
     keyPrefix: data.keyPrefix,
     keyHash: data.keyHash,
     permissions: Array.isArray(data.permissions) ? data.permissions : [],
@@ -71,6 +78,8 @@ export async function createApiToken(
     .collection('apiTokens')
     .add({
       name: data.name,
+      actorDisplayName: data.actorDisplayName,
+      actorIcon: data.actorIcon,
       keyPrefix,
       keyHash,
       permissions: data.permissions,
@@ -86,6 +95,8 @@ export async function createApiToken(
       id: docRef.id,
       userId,
       name: data.name,
+      actorDisplayName: data.actorDisplayName,
+      actorIcon: data.actorIcon,
       keyPrefix,
       keyHash,
       permissions: data.permissions,
@@ -174,6 +185,9 @@ export async function validateApiToken(token: string): Promise<AuthenticatedApiT
   return {
     id: tokenDoc.id,
     userId: parentUserRef.id,
+    name: data.name,
+    actorDisplayName: typeof data.actorDisplayName === 'string' ? data.actorDisplayName : null,
+    actorIcon: typeof data.actorIcon === 'string' ? data.actorIcon : null,
     permissions: Array.isArray(data.permissions) ? data.permissions : [],
     projectIds: Array.isArray(data.projectIds) ? data.projectIds : null,
   };

--- a/src/lib/auth/authenticateRequest.ts
+++ b/src/lib/auth/authenticateRequest.ts
@@ -5,6 +5,9 @@ import { verifyAuthToken } from '@/lib/firebase/admin';
 export interface AuthenticatedRequest {
   userId: string;
   authType: 'firebase' | 'api-token';
+  tokenName: string | null;
+  actorDisplayName: string | null;
+  actorIcon: string | null;
   permissions: ApiKeyPermission[] | null;
   projectIds: string[] | null;
   tokenId: string | null;
@@ -26,6 +29,9 @@ export async function authenticateRequest(authHeader: string | null): Promise<Au
     return {
       userId: apiToken.userId,
       authType: 'api-token',
+      tokenName: apiToken.name,
+      actorDisplayName: apiToken.actorDisplayName,
+      actorIcon: apiToken.actorIcon,
       permissions: apiToken.permissions,
       projectIds: apiToken.projectIds,
       tokenId: apiToken.id,
@@ -36,6 +42,9 @@ export async function authenticateRequest(authHeader: string | null): Promise<Au
   return {
     userId: firebaseUser.uid,
     authType: 'firebase',
+    tokenName: null,
+    actorDisplayName: null,
+    actorIcon: null,
     permissions: null,
     projectIds: null,
     tokenId: null,

--- a/src/lib/firebase/admin-projects.ts
+++ b/src/lib/firebase/admin-projects.ts
@@ -83,6 +83,8 @@ export interface ProjectTaskCommentItem {
   taskId: string;
   content: string;
   authorId: string;
+  authorLabel?: string;
+  authorIcon?: string | null;
   mentions: string[];
   attachments: CommentAttachment[];
   createdAt: string | null;
@@ -211,6 +213,8 @@ function mapCommentToApiItem(
     taskId,
     content: typeof data.content === 'string' ? data.content : '',
     authorId: typeof data.authorId === 'string' ? data.authorId : '',
+    authorLabel: typeof data.authorLabel === 'string' ? data.authorLabel : undefined,
+    authorIcon: typeof data.authorIcon === 'string' ? data.authorIcon : null,
     mentions:
       Array.isArray(data.mentions) && data.mentions.every((item) => typeof item === 'string')
         ? data.mentions
@@ -691,6 +695,8 @@ export async function createProjectTaskComment(
   input: {
     content: string;
     mentions?: string[];
+    authorLabel?: string;
+    authorIcon?: string | null;
   }
 ): Promise<{ comment: ProjectTaskCommentItem }> {
   const db = getAdminDb();
@@ -711,6 +717,8 @@ export async function createProjectTaskComment(
       taskId,
       content: input.content,
       authorId: userId,
+      authorLabel: input.authorLabel,
+      authorIcon: input.authorIcon ?? null,
       mentions: input.mentions ?? [],
       attachments: [],
       createdAt: now,

--- a/src/lib/firebase/admin.ts
+++ b/src/lib/firebase/admin.ts
@@ -148,3 +148,20 @@ export async function saveUserAIProjectAccessSettings(
     { merge: true }
   );
 }
+
+export async function getUserProfileSummary(
+  userId: string
+): Promise<{ displayName: string | null; photoURL: string | null }> {
+  const db = getAdminDb();
+  const userDoc = await db.collection('users').doc(userId).get();
+
+  if (!userDoc.exists) {
+    return { displayName: null, photoURL: null };
+  }
+
+  const data = userDoc.data();
+  return {
+    displayName: typeof data?.displayName === 'string' ? data.displayName : null,
+    photoURL: typeof data?.photoURL === 'string' ? data.photoURL : null,
+  };
+}

--- a/src/lib/firebase/apiKeys.ts
+++ b/src/lib/firebase/apiKeys.ts
@@ -36,6 +36,8 @@ export async function createApiKey(
 
   const docRef = await addDoc(collection(db, 'apiKeys'), {
     name: data.name,
+    actorDisplayName: data.actorDisplayName,
+    actorIcon: data.actorIcon,
     keyPrefix,
     keyHash,
     userId,
@@ -50,6 +52,8 @@ export async function createApiKey(
   const apiKey: ApiKey = {
     id: docRef.id,
     name: data.name,
+    actorDisplayName: data.actorDisplayName,
+    actorIcon: data.actorIcon,
     keyPrefix,
     keyHash,
     userId,
@@ -79,6 +83,8 @@ export async function getUserApiKeys(userId: string): Promise<ApiKey[]> {
     return {
       id: doc.id,
       name: data.name,
+      actorDisplayName: data.actorDisplayName || null,
+      actorIcon: data.actorIcon || null,
       keyPrefix: data.keyPrefix,
       keyHash: data.keyHash,
       userId: data.userId,
@@ -128,6 +134,8 @@ export async function validateApiKey(plainTextKey: string): Promise<ApiKey | nul
   return {
     id: doc.id,
     name: data.name,
+    actorDisplayName: data.actorDisplayName || null,
+    actorIcon: data.actorIcon || null,
     keyPrefix: data.keyPrefix,
     keyHash: data.keyHash,
     userId: data.userId,

--- a/src/lib/firebase/firestore.ts
+++ b/src/lib/firebase/firestore.ts
@@ -737,6 +737,8 @@ export async function createComment(
     {
       content: data.content,
       authorId: data.authorId,
+      authorLabel: data.authorLabel,
+      authorIcon: data.authorIcon ?? null,
       mentions: data.mentions || [],
       attachments: data.attachments || [],
       taskId,

--- a/src/types/apiKey.ts
+++ b/src/types/apiKey.ts
@@ -11,6 +11,8 @@ export type ApiKeyPermission =
 export interface ApiKey {
   id: string;
   name: string;
+  actorDisplayName: string | null;
+  actorIcon: string | null;
   keyPrefix: string;           // First 8 chars for display (e.g., "tf_abc123...")
   keyHash: string;             // SHA-256 hash of full key
   userId: string;              // Owner user ID
@@ -24,6 +26,8 @@ export interface ApiKey {
 
 export interface ApiKeyCreateData {
   name: string;
+  actorDisplayName: string | null;
+  actorIcon: string | null;
   permissions: ApiKeyPermission[];
   projectIds: string[] | null;
   expiresAt: Date | null;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -118,6 +118,8 @@ export interface Comment {
   taskId: string;
   content: string;
   authorId: string;
+  authorLabel?: string;
+  authorIcon?: string | null;
   mentions: string[];
   attachments?: CommentAttachment[];
   createdAt: Date;


### PR DESCRIPTION
## Summary
- add `actorDisplayName` and `actorIcon` metadata to API tokens
- expose those fields in the API key management UI and token routes
- show `user via actor` with an optional icon for PAT-authored task comments

## Testing
- npm run audit
- npm run lint
- npm run test:run
- npm run build
- npm run test:e2e:smoke

Closes #37
