### PR TITLE
Add Codex skill for TaskFlow delivery workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,3 +89,4 @@ When changing APIs or Firebase data shapes:
 - call out compatibility concerns in the PR
 
 See [`docs/TASKFLOW_GITHUB_TRIAGE.md`](./docs/TASKFLOW_GITHUB_TRIAGE.md) for the TaskFlow-to-GitHub backlog handoff rules.
+See [`docs/AI_DELIVERY_WORKFLOW.md`](./docs/AI_DELIVERY_WORKFLOW.md) for the full TaskFlow-to-GitHub delivery loop and sync-back expectations.

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Current integration routes:
 See [`docs/API.md`](./docs/API.md) for the current API surface and auth model.
 See [`docs/API_INTEGRATION.md`](./docs/API_INTEGRATION.md) for curl examples and integration flow.
 See [`docs/AI_ACCESS_CONTROL.md`](./docs/AI_ACCESS_CONTROL.md) for project-level AI access rules.
+See [`docs/AI_DELIVERY_WORKFLOW.md`](./docs/AI_DELIVERY_WORKFLOW.md) for the TaskFlow-to-GitHub AI delivery loop.
 See [`docs/GITHUB_WORKFLOW.md`](./docs/GITHUB_WORKFLOW.md) for GitHub workflow rules.
 See [`docs/LINT_DEBT.md`](./docs/LINT_DEBT.md) for current lint status and maintenance rules.
 See [`docs/ESLINT10_TRACKING.md`](./docs/ESLINT10_TRACKING.md) for the deferred ESLint 10 upgrade.
@@ -135,5 +136,6 @@ See [`docs/E2E_STRATEGY.md`](./docs/E2E_STRATEGY.md) for the current test-mode s
 
 - API token management UI is under `src/app/(dashboard)/settings/api-keys/page.tsx`
 - AI project access settings UI is under `src/app/(dashboard)/settings/ai/page.tsx`
+- Versioned Codex skill source for this delivery loop is under `codex-skills/taskflow-github-delivery/`
 - Firebase rules and indexes are versioned in `firestore.rules`, `firestore.indexes.json`, and `storage.rules`
 - Existing AI routes remain under `src/app/api/ai`

--- a/codex-skills/taskflow-github-delivery/SKILL.md
+++ b/codex-skills/taskflow-github-delivery/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: taskflow-github-delivery
+description: Triage TaskFlow board tasks, mirror them into GitHub issues only after classification, implement changes in the TaskFlow repository, open and merge pull requests, and sync `[AIからのメッセージ]` progress back to the originating TaskFlow task. Use when working in `/Users/hgs/devel/project_manager/taskflow` on requests that begin from a TaskFlow task or need GitHub Issue and PR coordination with TaskFlow status feedback.
+---
+
+# TaskFlow GitHub Delivery
+
+## Overview
+
+Use this skill to run the delivery loop between TaskFlow and GitHub for this repository.
+Treat TaskFlow as the runtime backlog and GitHub as the source of truth for code review,
+merge history, and release state.
+
+## Workflow
+
+1. Build context first.
+   - Capture the TaskFlow `projectId`, `taskId`, and board URL when the request starts from a TaskFlow task.
+   - Read `/Users/hgs/devel/project_manager/taskflow/docs/TASKFLOW_GITHUB_TRIAGE.md` before creating or updating a GitHub Issue.
+   - Read `/Users/hgs/devel/project_manager/taskflow/docs/API_INTEGRATION.md` when you need API examples or token scope details.
+2. Triage before mirroring.
+   - Inspect the current UI, API, or code path before treating the task as new work.
+   - Classify the request as `already implemented`, `partially implemented`, `reproducible gap`, or `needs clarification`.
+   - Leave an `AI triage:` comment in the GitHub Issue and close it immediately if current `main` already satisfies the request.
+3. Create GitHub artifacts deliberately.
+   - Preserve the source TaskFlow task ID and board URL in the GitHub Issue body.
+   - Use `codex/<short-name>` for Codex-created working branches.
+   - Open a PR that links the Issue and keeps scope narrow.
+4. Implement and verify.
+   - Update docs in the same change when API shape, workflow, or operator expectations change.
+   - Run `npm run audit`, `npm run lint`, `npm run test:run`, `npm run build`, and `npm run test:e2e:smoke` from `/Users/hgs/devel/project_manager/taskflow`.
+5. Sync progress back to TaskFlow.
+   - Leave an `[AIからのメッセージ]` comment on the originating TaskFlow task when triage completes, when a PR opens, and when work merges or closes without code.
+   - Use `scripts/post_taskflow_ai_message.py` to post deterministic sync-back comments instead of retyping curl payloads each time.
+6. Close the loop.
+   - After merge, sync the final GitHub Issue number, PR number, and implementation summary back to TaskFlow.
+   - Keep the GitHub Project item state aligned when the repository workflow requires it.
+
+## Guardrails
+
+- Do not mirror vague human wording into GitHub without interpretation.
+- Prefer `already implemented` or `partially implemented` when they match reality.
+- Do not claim the loop is closed until the originating TaskFlow task has an AI message with the final GitHub status.
+- If the workflow changes, update the repository docs because GitHub is the source of truth for the process.
+
+## Resources
+
+- Read `references/workflow.md` for the exact checklist and sync-back expectations.
+- Run `scripts/post_taskflow_ai_message.py --help` to post `[AIからのメッセージ]` comments back to TaskFlow.

--- a/codex-skills/taskflow-github-delivery/agents/openai.yaml
+++ b/codex-skills/taskflow-github-delivery/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "TaskFlow GitHub Delivery"
+  short_description: "Triage TaskFlow tasks and sync GitHub delivery."
+  default_prompt: "Triage the TaskFlow task, decide whether it is already implemented or needs work, create or update the matching GitHub issue, implement the change if needed, and sync an [AIからのメッセージ] comment with issue and PR details back to TaskFlow."

--- a/codex-skills/taskflow-github-delivery/references/workflow.md
+++ b/codex-skills/taskflow-github-delivery/references/workflow.md
@@ -1,0 +1,70 @@
+# TaskFlow-GitHub Delivery Checklist
+
+## Inputs To Capture
+
+- TaskFlow `projectId`
+- TaskFlow `taskId`
+- source board URL
+- GitHub repository: `Naofumi-1000ri/taskflow`
+- PAT with the minimum required TaskFlow scope for the target project
+
+## Triage States
+
+Use exactly one of these classifications before implementation:
+
+- `already implemented`
+- `partially implemented`
+- `reproducible gap`
+- `needs clarification`
+
+The GitHub Issue comment should state:
+
+1. the classification
+2. the current implementation that already exists
+3. the remaining gap
+4. the clarification needed, if any
+
+## GitHub Issue Expectations
+
+- keep the source TaskFlow task ID in the body
+- keep the source board URL in the body when available
+- add an `AI triage:` comment before coding starts
+- close the Issue immediately if current `main` already satisfies it
+
+## TaskFlow Sync-Back Messages
+
+Use this structure for comment content:
+
+```text
+[AIからのメッセージ]
+GitHub Issue: #123
+GitHub PR: #456
+状態: merged
+詳細: APIキーに表示名とアイコンを追加し、PAT経由コメントで `user via actor` を表示するようにしました。
+```
+
+If there is no PR yet, send `GitHub PR: なし`.
+If there is no code change, keep the final line explicit, for example:
+
+```text
+詳細: 現行実装で要件を満たしていることを確認したため、Issue を close しました。PR はありません。
+```
+
+## Required Verification
+
+Run from `/Users/hgs/devel/project_manager/taskflow`:
+
+```bash
+npm run audit
+npm run lint
+npm run test:run
+npm run build
+npm run test:e2e:smoke
+```
+
+## Repository Docs To Keep In Sync
+
+- `/Users/hgs/devel/project_manager/taskflow/docs/TASKFLOW_GITHUB_TRIAGE.md`
+- `/Users/hgs/devel/project_manager/taskflow/docs/GITHUB_WORKFLOW.md`
+- `/Users/hgs/devel/project_manager/taskflow/docs/API_INTEGRATION.md`
+- `/Users/hgs/devel/project_manager/taskflow/docs/AI_DELIVERY_WORKFLOW.md`

--- a/codex-skills/taskflow-github-delivery/scripts/post_taskflow_ai_message.py
+++ b/codex-skills/taskflow-github-delivery/scripts/post_taskflow_ai_message.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+
+def build_content(issue, pr, status, details, extra_lines):
+    lines = ["[AIからのメッセージ]"]
+    lines.append(f"GitHub Issue: #{issue}" if issue else "GitHub Issue: なし")
+    lines.append(f"GitHub PR: #{pr}" if pr else "GitHub PR: なし")
+    if status:
+        lines.append(f"状態: {status}")
+    lines.append(f"詳細: {details}")
+    lines.extend(extra_lines)
+    return "\n".join(lines)
+
+
+def parse_mentions(raw):
+    if not raw:
+        return []
+    return [item.strip() for item in raw.split(",") if item.strip()]
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Post an [AIからのメッセージ] sync-back comment to a TaskFlow task.",
+    )
+    parser.add_argument("--project-id", required=True, help="TaskFlow project ID")
+    parser.add_argument("--task-id", required=True, help="TaskFlow task ID")
+    parser.add_argument(
+        "--base-url",
+        default=os.environ.get("TASKFLOW_BASE_URL", "https://taskflow-1000ri.vercel.app"),
+        help="TaskFlow base URL. Defaults to $TASKFLOW_BASE_URL or production.",
+    )
+    parser.add_argument(
+        "--token",
+        default=os.environ.get("TASKFLOW_PAT"),
+        help="TaskFlow PAT. Defaults to $TASKFLOW_PAT.",
+    )
+    parser.add_argument("--issue", help="GitHub issue number without #")
+    parser.add_argument("--pr", help="GitHub PR number without #")
+    parser.add_argument("--status", help="Short state such as triage, review, merged")
+    parser.add_argument("--details", required=True, help="Japanese sync-back summary")
+    parser.add_argument(
+        "--extra-line",
+        action="append",
+        default=[],
+        help="Additional line to append to the message. May be repeated.",
+    )
+    parser.add_argument(
+        "--mentions",
+        default="",
+        help="Comma-separated mention IDs to include in the API payload.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the payload instead of sending the request.",
+    )
+    args = parser.parse_args()
+
+    content = build_content(args.issue, args.pr, args.status, args.details, args.extra_line)
+    payload = {
+        "content": content,
+        "mentions": parse_mentions(args.mentions),
+    }
+
+    if args.dry_run:
+        json.dump(payload, sys.stdout, ensure_ascii=False, indent=2)
+        sys.stdout.write("\n")
+        return 0
+
+    if not args.token:
+        sys.stderr.write("Missing TaskFlow PAT. Pass --token or set TASKFLOW_PAT.\n")
+        return 2
+
+    url = (
+        f"{args.base_url.rstrip('/')}/api/projects/{args.project_id}"
+        f"/tasks/{args.task_id}/comments"
+    )
+    data = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=data,
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {args.token}",
+            "Content-Type": "application/json",
+        },
+    )
+
+    try:
+        with urllib.request.urlopen(request) as response:
+            body = response.read().decode("utf-8")
+    except urllib.error.HTTPError as error:
+        error_body = error.read().decode("utf-8", errors="replace")
+        sys.stderr.write(f"TaskFlow API error {error.code}: {error_body}\n")
+        return 1
+    except urllib.error.URLError as error:
+        sys.stderr.write(f"TaskFlow request failed: {error.reason}\n")
+        return 1
+
+    sys.stdout.write(body)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/AI_DELIVERY_WORKFLOW.md
+++ b/docs/AI_DELIVERY_WORKFLOW.md
@@ -1,0 +1,59 @@
+# AI Delivery Workflow
+
+This repository blends project management and implementation work.
+TaskFlow holds the runtime backlog. GitHub holds the source of truth for issues, code review,
+merge history, and delivery state.
+
+## Delivery Loop
+
+1. Start from a TaskFlow task or a GitHub Issue.
+2. If the source is TaskFlow, inspect the current implementation before creating or updating a GitHub Issue.
+3. Classify the request as `already implemented`, `partially implemented`, `reproducible gap`, or `needs clarification`.
+4. Leave an `AI triage:` comment in the GitHub Issue.
+5. Implement only after the task is explicit enough.
+6. Open a PR, run the required checks, and merge through the normal GitHub workflow.
+7. Write an `[AIからのメッセージ]` comment back to the originating TaskFlow task with the GitHub Issue number, PR number, and delivery summary.
+
+## Required Sync-Back Points
+
+Leave a TaskFlow AI comment at these milestones:
+
+- triage completed
+- meaningful scope change during implementation
+- PR opened
+- merged
+- closed without code
+
+The message should include:
+
+- GitHub Issue number
+- GitHub PR number or `なし`
+- a short status line
+- a short Japanese summary of what changed or why the Issue closed
+
+## Source Of Truth Rule
+
+If the local Codex skill and this repository document ever diverge, this repository wins.
+Update docs in the same PR when the workflow changes.
+
+## Codex Skill
+
+The local skill name is `taskflow-github-delivery`.
+
+Versioned skill source lives in:
+
+- `/Users/hgs/devel/project_manager/taskflow/codex-skills/taskflow-github-delivery`
+
+The installed local copy lives in:
+
+- `$CODEX_HOME/skills/taskflow-github-delivery`
+
+The helper script for posting AI sync-back comments is:
+
+- `/Users/hgs/devel/project_manager/taskflow/codex-skills/taskflow-github-delivery/scripts/post_taskflow_ai_message.py`
+
+## Related Docs
+
+- [`TASKFLOW_GITHUB_TRIAGE.md`](./TASKFLOW_GITHUB_TRIAGE.md)
+- [`GITHUB_WORKFLOW.md`](./GITHUB_WORKFLOW.md)
+- [`API_INTEGRATION.md`](./API_INTEGRATION.md)

--- a/docs/GITHUB_WORKFLOW.md
+++ b/docs/GITHUB_WORKFLOW.md
@@ -85,6 +85,7 @@ Suggested automation rules:
 - merged PR closes Issue and moves it to `Done`
 
 For TaskFlow board items that are synced into GitHub Issues, follow the triage rules in [`TASKFLOW_GITHUB_TRIAGE.md`](./TASKFLOW_GITHUB_TRIAGE.md) before implementation starts.
+Use [`AI_DELIVERY_WORKFLOW.md`](./AI_DELIVERY_WORKFLOW.md) when the work also needs TaskFlow sync-back comments and Codex skill support.
 
 ## Branch Protection
 

--- a/docs/TASKFLOW_GITHUB_TRIAGE.md
+++ b/docs/TASKFLOW_GITHUB_TRIAGE.md
@@ -82,3 +82,5 @@ Because this repository is explicitly blending project management and developmen
 - preserve the source board URL when possible
 - document the triage decision in the Issue thread
 - document any new workflow rule in repository docs when the process changes
+
+See [`AI_DELIVERY_WORKFLOW.md`](./AI_DELIVERY_WORKFLOW.md) for the end-to-end delivery loop after triage, including TaskFlow sync-back comments and the local Codex skill source.


### PR DESCRIPTION
## Summary
- add a versioned Codex skill source for the TaskFlow -> GitHub -> sync-back delivery loop
- add a helper script for posting `[AIからのメッセージ]` comments back to TaskFlow tasks
- document the workflow in the repository and link it from the existing docs

## Verification
- `python3 /Users/hgs/.codex/skills/.system/skill-creator/scripts/quick_validate.py /Users/hgs/devel/project_manager/taskflow/codex-skills/taskflow-github-delivery`
- `python3 /Users/hgs/devel/project_manager/taskflow/codex-skills/taskflow-github-delivery/scripts/post_taskflow_ai_message.py --project-id demo-project --task-id demo-task --issue 39 --status triage --details "workflow skill を追加します。" --dry-run`
- `python3 /Users/hgs/.codex/skills/.system/skill-creator/scripts/quick_validate.py /Users/hgs/.codex/skills/taskflow-github-delivery`

Closes #39
