### PR TITLE
fix: avoid undefined author labels in comments

### DIFF
--- a/src/app/api/projects/[projectId]/tasks/[taskId]/comments/route.test.ts
+++ b/src/app/api/projects/[projectId]/tasks/[taskId]/comments/route.test.ts
@@ -140,4 +140,48 @@ describe('POST /api/projects/[projectId]/tasks/[taskId]/comments', () => {
     expect(response.status).toBe(403);
     await expect(response.json()).resolves.toEqual({ error: 'Forbidden' });
   });
+
+  it('omits optional author metadata for non api-token auth', async () => {
+    mockedAuthenticateRequest.mockResolvedValue({
+      userId: 'user-1',
+      authType: 'firebase',
+      tokenName: null,
+      actorDisplayName: null,
+      actorIcon: null,
+      permissions: ['tasks:write'],
+      projectIds: null,
+      tokenId: null,
+    });
+    mockedCreateProjectTaskComment.mockResolvedValue({
+      comment: {
+        id: 'comment-2',
+        taskId: 'task-1',
+        content: 'Session comment',
+        authorId: 'user-1',
+        mentions: [],
+        attachments: [],
+        createdAt: '2026-03-13T00:00:00.000Z',
+        updatedAt: '2026-03-13T00:00:00.000Z',
+      },
+    });
+
+    const request = new NextRequest('http://localhost/api/projects/project-1/tasks/task-1/comments', {
+      method: 'POST',
+      body: JSON.stringify({ content: 'Session comment' }),
+      headers: {
+        Authorization: 'Bearer session_token',
+        'Content-Type': 'application/json',
+      },
+    });
+
+    const response = await POST(request, {
+      params: Promise.resolve({ projectId: 'project-1', taskId: 'task-1' }),
+    });
+
+    expect(response.status).toBe(201);
+    expect(mockedCreateProjectTaskComment).toHaveBeenCalledWith('project-1', 'task-1', 'user-1', {
+      content: 'Session comment',
+      mentions: undefined,
+    });
+  });
 });

--- a/src/app/api/projects/[projectId]/tasks/[taskId]/comments/route.ts
+++ b/src/app/api/projects/[projectId]/tasks/[taskId]/comments/route.ts
@@ -73,8 +73,8 @@ export async function POST(request: NextRequest, context: RouteContext) {
 
     const result = await createProjectTaskComment(projectId, taskId, auth.userId, {
       ...commentInput,
-      authorLabel,
-      authorIcon,
+      ...(authorLabel !== undefined ? { authorLabel } : {}),
+      ...(authorIcon !== undefined ? { authorIcon } : {}),
     });
     return NextResponse.json(result, { status: 201 });
   } catch (error) {

--- a/src/components/task/TaskDetailModal.tsx
+++ b/src/components/task/TaskDetailModal.tsx
@@ -296,7 +296,7 @@ export function TaskDetailModal({
     if (user && (commentText.trim() || pendingFiles.length > 0)) {
       setIsSubmittingComment(true);
       try {
-        await addComment(commentText.trim(), user.id, [], pendingFiles);
+        await addComment(commentText.trim(), user.id, user.displayName, [], pendingFiles);
         setCommentText('');
         setPendingFiles([]);
       } catch (error) {

--- a/src/hooks/useTaskDetails.ts
+++ b/src/hooks/useTaskDetails.ts
@@ -187,7 +187,13 @@ export function useTaskDetails(projectId: string | null, taskId: string | null) 
 
   // Add comment (with optional attachments)
   const addComment = useCallback(
-    async (content: string, authorId: string, mentions: string[] = [], files: File[] = []) => {
+    async (
+      content: string,
+      authorId: string,
+      authorLabel?: string,
+      mentions: string[] = [],
+      files: File[] = []
+    ) => {
       if (!projectId || !taskId) return;
 
       // Upload attachments first
@@ -202,6 +208,7 @@ export function useTaskDetails(projectId: string | null, taskId: string | null) 
       await createComment(projectId, taskId, {
         content,
         authorId,
+        authorLabel,
         mentions,
         attachments: commentAttachments,
       });

--- a/src/lib/firebase/admin-projects.ts
+++ b/src/lib/firebase/admin-projects.ts
@@ -26,6 +26,12 @@ interface AdminList {
   autoCompleteOnEnter?: boolean;
 }
 
+function omitUndefinedFields<T extends Record<string, unknown>>(data: T): T {
+  return Object.fromEntries(
+    Object.entries(data).filter(([, value]) => value !== undefined)
+  ) as T;
+}
+
 export interface ProjectStatusSummary {
   totalTasks: number;
   completedTasks: number;
@@ -713,7 +719,7 @@ export async function createProjectTaskComment(
     .collection('tasks')
     .doc(taskId)
     .collection('comments')
-    .add({
+    .add(omitUndefinedFields({
       taskId,
       content: input.content,
       authorId: userId,
@@ -723,7 +729,7 @@ export async function createProjectTaskComment(
       attachments: [],
       createdAt: now,
       updatedAt: now,
-    });
+    }));
 
   const commentSnapshot = await commentRef.get();
   if (!commentSnapshot.exists) {

--- a/src/lib/firebase/firestore.comments.test.ts
+++ b/src/lib/firebase/firestore.comments.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  addDocMock,
+  collectionMock,
+  serverTimestampMock,
+  getFirebaseDbMock,
+} = vi.hoisted(() => ({
+  addDocMock: vi.fn(),
+  collectionMock: vi.fn(),
+  serverTimestampMock: vi.fn(() => 'SERVER_TIMESTAMP'),
+  getFirebaseDbMock: vi.fn(() => 'DB'),
+}));
+
+vi.mock('firebase/firestore', () => ({
+  collection: collectionMock,
+  doc: vi.fn(),
+  addDoc: addDocMock,
+  updateDoc: vi.fn(),
+  deleteDoc: vi.fn(),
+  getDoc: vi.fn(),
+  getDocs: vi.fn(),
+  setDoc: vi.fn(),
+  query: vi.fn(),
+  where: vi.fn(),
+  orderBy: vi.fn(),
+  onSnapshot: vi.fn(),
+  serverTimestamp: serverTimestampMock,
+  writeBatch: vi.fn(),
+  Timestamp: class Timestamp {},
+  documentId: vi.fn(),
+  limit: vi.fn(),
+}));
+
+vi.mock('./config', () => ({
+  getFirebaseDb: getFirebaseDbMock,
+}));
+
+import { createComment } from './firestore';
+
+describe('createComment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    collectionMock.mockReturnValue('COMMENTS_COLLECTION');
+    addDocMock.mockResolvedValue({ id: 'comment-1' });
+  });
+
+  it('omits undefined optional fields from the Firestore payload', async () => {
+    await expect(
+      createComment('project-1', 'task-1', {
+        content: 'Comment with image',
+        authorId: 'user-1',
+        mentions: [],
+        attachments: [],
+      })
+    ).resolves.toBe('comment-1');
+
+    expect(collectionMock).toHaveBeenCalledWith(
+      'DB',
+      'projects',
+      'project-1',
+      'tasks',
+      'task-1',
+      'comments'
+    );
+    expect(addDocMock).toHaveBeenCalledWith('COMMENTS_COLLECTION', {
+      content: 'Comment with image',
+      authorId: 'user-1',
+      authorIcon: null,
+      mentions: [],
+      attachments: [],
+      taskId: 'task-1',
+      createdAt: 'SERVER_TIMESTAMP',
+      updatedAt: 'SERVER_TIMESTAMP',
+    });
+  });
+
+  it('preserves authorLabel when it is provided', async () => {
+    await createComment('project-1', 'task-1', {
+      content: 'Named comment',
+      authorId: 'user-1',
+      authorLabel: 'Naofumi',
+      mentions: [],
+      attachments: [],
+    });
+
+    expect(addDocMock).toHaveBeenCalledWith('COMMENTS_COLLECTION', {
+      content: 'Named comment',
+      authorId: 'user-1',
+      authorLabel: 'Naofumi',
+      authorIcon: null,
+      mentions: [],
+      attachments: [],
+      taskId: 'task-1',
+      createdAt: 'SERVER_TIMESTAMP',
+      updatedAt: 'SERVER_TIMESTAMP',
+    });
+  });
+});

--- a/src/lib/firebase/firestore.ts
+++ b/src/lib/firebase/firestore.ts
@@ -64,6 +64,12 @@ function convertDoc<T>(doc: DocumentData, id: string): T {
   } as T;
 }
 
+function omitUndefinedFields<T extends Record<string, unknown>>(data: T): T {
+  return Object.fromEntries(
+    Object.entries(data).filter(([, value]) => value !== undefined)
+  ) as T;
+}
+
 // ==================== Projects ====================
 
 export async function createProject(
@@ -734,7 +740,7 @@ export async function createComment(
   const db = getFirebaseDb();
   const commentRef = await addDoc(
     collection(db, 'projects', projectId, 'tasks', taskId, 'comments'),
-    {
+    omitUndefinedFields({
       content: data.content,
       authorId: data.authorId,
       authorLabel: data.authorLabel,
@@ -744,7 +750,7 @@ export async function createComment(
       taskId,
       createdAt: serverTimestamp(),
       updatedAt: serverTimestamp(),
-    }
+    })
   );
   return commentRef.id;
 }


### PR DESCRIPTION
## Summary
- omit undefined optional comment fields before Firestore writes
- populate `authorLabel` from the signed-in user in the first-party UI path
- add regression coverage for the Firestore payload and the comment API route

## Linked Issue
- Closes #45

## Verification
- [x] `npm run test:run`
- [x] `npm run test:e2e:smoke`
- [x] Manual check completed if UI or API behavior changed
- [x] `npm run lint`
- [x] `npm run build`
- [ ] `npm run audit` (currently fails on existing `flatted`, `next`, and `undici` advisories already present in the branch baseline)

## Impact
- Affected areas: task comments, Firestore comment writes
- Breaking changes: none
- Follow-up work: separate dependency maintenance issue for the existing audit findings if they should block merge
