### PR TITLE
chore: automate GitHub issue to deploy flow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,7 @@
 ## Linked Issue
 
 - Closes #
+- Required for Project v2 automation
 
 ## Verification
 

--- a/.github/workflows/taskflow-deploy.yml
+++ b/.github/workflows/taskflow-deploy.yml
@@ -1,0 +1,81 @@
+name: taskflow-deploy
+
+on:
+  workflow_run:
+    workflows:
+      - taskflow-ci
+    types:
+      - completed
+
+concurrency:
+  group: taskflow-production-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy-production:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main'
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check deploy configuration
+        id: config
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
+        run: |
+          if [ -z "$VERCEL_TOKEN" ] || [ -z "$VERCEL_ORG_ID" ] || [ -z "$VERCEL_PROJECT_ID" ]; then
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "Production deploy skipped. Configure VERCEL_TOKEN, VERCEL_ORG_ID, and VERCEL_PROJECT_ID to enable it." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "ready=true" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout merged revision
+        if: steps.config.outputs.ready == 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Setup Node
+        if: steps.config.outputs.ready == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        if: steps.config.outputs.ready == 'true'
+        run: npm ci
+
+      - name: Pull Vercel production environment
+        if: steps.config.outputs.ready == 'true'
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
+        run: npx vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
+
+      - name: Build Vercel artifact
+        if: steps.config.outputs.ready == 'true'
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
+        run: npx vercel build --prod --token="$VERCEL_TOKEN"
+
+      - name: Deploy to Vercel production
+        if: steps.config.outputs.ready == 'true'
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
+        run: npx vercel deploy --prebuilt --prod --token="$VERCEL_TOKEN"

--- a/.github/workflows/taskflow-project-automation.yml
+++ b/.github/workflows/taskflow-project-automation.yml
@@ -1,0 +1,257 @@
+name: taskflow-project-automation
+
+on:
+  issues:
+    types:
+      - opened
+      - reopened
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - converted_to_draft
+      - closed
+
+jobs:
+  sync-project-status:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+
+    steps:
+      - name: Sync Project v2 status
+        uses: actions/github-script@v7
+        env:
+          PROJECTV2_OWNER: ${{ vars.GH_PROJECTV2_OWNER }}
+          PROJECTV2_NUMBER: ${{ vars.GH_PROJECTV2_NUMBER }}
+          PROJECTV2_TOKEN: ${{ secrets.PROJECTV2_TOKEN }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const ownerLogin = process.env.PROJECTV2_OWNER || context.repo.owner;
+            const projectNumberRaw = process.env.PROJECTV2_NUMBER?.trim();
+            const projectToken = process.env.PROJECTV2_TOKEN?.trim();
+
+            if (!projectToken || !projectNumberRaw) {
+              core.notice(
+                'Skipping Project v2 sync because PROJECTV2_TOKEN or GH_PROJECTV2_NUMBER is not configured.'
+              );
+              return;
+            }
+
+            const projectNumber = Number(projectNumberRaw);
+            if (!Number.isInteger(projectNumber) || projectNumber <= 0) {
+              core.setFailed(`Invalid GH_PROJECTV2_NUMBER: ${projectNumberRaw}`);
+              return;
+            }
+
+            async function graphQL(query, variables) {
+              const response = await fetch('https://api.github.com/graphql', {
+                method: 'POST',
+                headers: {
+                  Authorization: `bearer ${projectToken}`,
+                  'Content-Type': 'application/json',
+                  'User-Agent': 'taskflow-project-automation',
+                },
+                body: JSON.stringify({ query, variables }),
+              });
+
+              const payload = await response.json();
+              if (!response.ok || payload.errors) {
+                throw new Error(
+                  `GitHub GraphQL request failed: ${JSON.stringify(payload.errors || payload)}`
+                );
+              }
+
+              return payload.data;
+            }
+
+            async function getProjectConfig() {
+              const { data: owner } = await github.rest.users.getByUsername({
+                username: ownerLogin,
+              });
+              const ownerField = owner.type === 'Organization' ? 'organization' : 'user';
+              const data = await graphQL(
+                `query($owner: String!, $number: Int!) {
+                  ${ownerField}(login: $owner) {
+                    projectV2(number: $number) {
+                      id
+                      title
+                      fields(first: 50) {
+                        nodes {
+                          __typename
+                          ... on ProjectV2SingleSelectField {
+                            id
+                            name
+                            options {
+                              id
+                              name
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }`,
+                {
+                  owner: ownerLogin,
+                  number: projectNumber,
+                }
+              );
+
+              const project = data?.[ownerField]?.projectV2;
+              if (!project) {
+                throw new Error(`Project v2 ${ownerLogin}/${projectNumber} not found`);
+              }
+
+              const statusField = project.fields.nodes.find(
+                (field) => field.__typename === 'ProjectV2SingleSelectField' && field.name === 'Status'
+              );
+
+              if (!statusField) {
+                throw new Error('Project v2 is missing a single-select field named "Status"');
+              }
+
+              return { project, statusField };
+            }
+
+            async function getProjectItem(contentId, projectId) {
+              const data = await graphQL(
+                `query($contentId: ID!) {
+                  node(id: $contentId) {
+                    ... on Issue {
+                      projectItems(first: 20) {
+                        nodes {
+                          id
+                          project {
+                            id
+                          }
+                        }
+                      }
+                    }
+                    ... on PullRequest {
+                      projectItems(first: 20) {
+                        nodes {
+                          id
+                          project {
+                            id
+                          }
+                        }
+                      }
+                    }
+                  }
+                }`,
+                { contentId }
+              );
+
+              const items = data?.node?.projectItems?.nodes || [];
+              return items.find((item) => item.project.id === projectId) || null;
+            }
+
+            async function ensureProjectItem(contentId, projectId) {
+              const existing = await getProjectItem(contentId, projectId);
+              if (existing) {
+                return existing.id;
+              }
+
+              const data = await graphQL(
+                `mutation($projectId: ID!, $contentId: ID!) {
+                  addProjectV2ItemById(input: {
+                    projectId: $projectId
+                    contentId: $contentId
+                  }) {
+                    item {
+                      id
+                    }
+                  }
+                }`,
+                {
+                  projectId,
+                  contentId,
+                }
+              );
+
+              return data.addProjectV2ItemById.item.id;
+            }
+
+            async function setStatus(contentId, statusName, projectConfig) {
+              const option = projectConfig.statusField.options.find(
+                (candidate) => candidate.name === statusName
+              );
+
+              if (!option) {
+                throw new Error(`Project v2 status option "${statusName}" not found`);
+              }
+
+              const itemId = await ensureProjectItem(contentId, projectConfig.project.id);
+              await graphQL(
+                `mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                  updateProjectV2ItemFieldValue(input: {
+                    projectId: $projectId
+                    itemId: $itemId
+                    fieldId: $fieldId
+                    value: { singleSelectOptionId: $optionId }
+                  }) {
+                    projectV2Item {
+                      id
+                    }
+                  }
+                }`,
+                {
+                  projectId: projectConfig.project.id,
+                  itemId,
+                  fieldId: projectConfig.statusField.id,
+                  optionId: option.id,
+                }
+              );
+            }
+
+            function extractLinkedIssueNumbers(body) {
+              const matches = new Set();
+              const pattern = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b/gi;
+
+              for (const match of body.matchAll(pattern)) {
+                matches.add(Number(match[1]));
+              }
+
+              return [...matches];
+            }
+
+            const projectConfig = await getProjectConfig();
+
+            if (context.eventName === 'issues') {
+              await setStatus(context.payload.issue.node_id, 'Backlog', projectConfig);
+              core.info(`Synced issue #${context.payload.issue.number} to Backlog`);
+              return;
+            }
+
+            const pullRequest = context.payload.pull_request;
+            const linkedIssueNumbers = extractLinkedIssueNumbers(pullRequest.body || '');
+
+            if (linkedIssueNumbers.length === 0) {
+              core.notice(
+                `Skipping Project v2 PR sync because PR #${pullRequest.number} does not contain a closing issue reference.`
+              );
+              return;
+            }
+
+            let targetStatus = 'In Progress';
+            if (context.payload.action === 'ready_for_review') {
+              targetStatus = 'Review';
+            } else if (context.payload.action === 'closed') {
+              targetStatus = pullRequest.merged ? 'Done' : 'Ready';
+            }
+
+            for (const issueNumber of linkedIssueNumbers) {
+              const { data: issue } = await github.rest.issues.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+              });
+
+              await setStatus(issue.node_id, targetStatus, projectConfig);
+              core.info(`Synced issue #${issueNumber} to ${targetStatus}`);
+            }

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Current baseline:
 
 Weekly maintenance automation also runs `taskflow-maintenance`, which uploads a dependency health report and updates a tracking issue when findings exist.
 Known deferred update: `eslint@10.x` is intentionally held back until `eslint-config-next` becomes runtime-compatible.
+Issue-to-PR state sync now runs through `taskflow-project-automation`, and production deploy after merge is handled by `taskflow-deploy` once the required GitHub secrets and vars are configured.
 
 Current GitHub branch policy is tuned for single-operator maintenance:
 
@@ -104,6 +105,7 @@ See [`docs/API.md`](./docs/API.md) for the current API surface and auth model.
 See [`docs/API_INTEGRATION.md`](./docs/API_INTEGRATION.md) for curl examples and integration flow.
 See [`docs/AI_ACCESS_CONTROL.md`](./docs/AI_ACCESS_CONTROL.md) for project-level AI access rules.
 See [`docs/AI_DELIVERY_WORKFLOW.md`](./docs/AI_DELIVERY_WORKFLOW.md) for the TaskFlow-to-GitHub AI delivery loop.
+See [`docs/DEPLOYMENT.md`](./docs/DEPLOYMENT.md) for GitHub Project status automation and production deploy setup.
 See [`docs/GITHUB_WORKFLOW.md`](./docs/GITHUB_WORKFLOW.md) for GitHub workflow rules.
 See [`docs/LINT_DEBT.md`](./docs/LINT_DEBT.md) for current lint status and maintenance rules.
 See [`docs/ESLINT10_TRACKING.md`](./docs/ESLINT10_TRACKING.md) for the deferred ESLint 10 upgrade.

--- a/docs/BRANCH_PROTECTION.md
+++ b/docs/BRANCH_PROTECTION.md
@@ -43,6 +43,11 @@ Recommended repository-level merge settings:
 - disable rebase merge
 - delete head branch on merge
 
+## Deploy Behavior
+
+Production deploy is handled after merge by `taskflow-deploy`.
+Do not add deploy as a required pre-merge check. Keep `taskflow-ci` as the merge gate, and let deploy run from the successful `main` build.
+
 ## When To Tighten Rules
 
 If the repository moves beyond single-operator maintenance, turn these back on:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,61 @@
+# Deployment
+
+This repository deploys the production app after a merge to `main`.
+The default production target in this repository is Vercel because no alternative app-hosting pipeline is versioned here today.
+
+## Production Path
+
+1. A change lands through a pull request.
+2. `taskflow-ci` passes on the merged `main` commit.
+3. `taskflow-deploy` runs from that successful `main` CI result.
+4. The workflow builds and deploys the app to Vercel production.
+
+The deploy workflow is intentionally post-merge. It is not a branch protection gate.
+
+## Required Repository Configuration
+
+Configure these repository secrets and variables before relying on production deploys.
+
+Required secrets:
+
+- `VERCEL_TOKEN`: token used by GitHub Actions to deploy the app
+- `PROJECTV2_TOKEN`: token that can update the GitHub Project v2 item status
+
+Required repository variables:
+
+- `VERCEL_ORG_ID`: Vercel team or personal account id
+- `VERCEL_PROJECT_ID`: Vercel project id for this app
+- `GH_PROJECTV2_NUMBER`: the Project v2 number used for Issue tracking
+
+Optional repository variable:
+
+- `GH_PROJECTV2_OWNER`: the Project v2 owner login when the project does not live under the current repository owner
+
+If the Vercel values are missing, `taskflow-deploy` exits without deploying.
+If the Project v2 values are missing, `taskflow-project-automation` exits without changing issue status.
+
+## GitHub Project Automation
+
+`taskflow-project-automation` keeps linked Issues aligned with the delivery flow.
+
+Automatic transitions:
+
+- Issue `opened` or `reopened` -> `Backlog`
+- PR `opened`, `reopened`, or `converted_to_draft` -> linked Issue `In Progress`
+- PR `ready_for_review` -> linked Issue `Review`
+- PR `closed` with merge -> linked Issue `Done`
+- PR `closed` without merge -> linked Issue `Ready`
+
+Linked Issues are detected from the PR body.
+Use a closing reference such as `Closes #123` in every PR.
+
+## Repository Settings
+
+Keep these repository settings aligned with the automation:
+
+- require pull requests for `main`
+- require the `taskflow-ci` checks to pass before merge
+- enable squash merge
+- delete branch on merge
+
+The deploy workflow assumes merges reach `main` only after CI has already passed on the PR.

--- a/docs/GITHUB_WORKFLOW.md
+++ b/docs/GITHUB_WORKFLOW.md
@@ -79,7 +79,7 @@ Recommended columns:
 Suggested automation rules:
 
 - new Issues go to `Backlog`
-- assigned and scoped Issues move to `Ready`
+- scoped Issues move to `Ready`
 - linked PR opened moves Issue to `In Progress`
 - PR in review moves Issue to `Review`
 - merged PR closes Issue and moves it to `Done`
@@ -124,6 +124,12 @@ Repository merge settings should be:
 - rebase merge disabled
 - delete branch on merge enabled
 
+Production deployment:
+
+- `taskflow-deploy` runs after `taskflow-ci` succeeds on a `main` push
+- deploy configuration lives in [`DEPLOYMENT.md`](./DEPLOYMENT.md)
+- deploy is post-merge and does not replace the required PR checks
+
 ## Dependency Maintenance
 
 Dependency upkeep is automated with:
@@ -154,9 +160,7 @@ Current Project v2 workflow:
 Manual rules:
 
 - move new scoped issues into `Ready` only when acceptance criteria are clear
-- move an issue to `In Progress` when implementation starts, not when it is merely discussed
-- move an issue to `Review` when the linked PR is open
-- move an issue to `Done` only after the change is merged or intentionally completed without code
+- use a closing issue reference in every PR body, such as `Closes #123`
 
 TaskFlow-imported Issues should not move to `Ready` until they have an explicit `AI triage` comment that classifies them as:
 
@@ -165,11 +169,18 @@ TaskFlow-imported Issues should not move to `Ready` until they have an explicit 
 - `reproducible gap`
 - `needs clarification`
 
-Automation candidates to revisit later:
+Current automation:
 
-- set `In Progress` when a linked PR opens
-- set `Review` when a PR is marked ready for review
-- set `Done` on merge or close with resolution
+- `taskflow-project-automation` adds new Issues to the configured Project v2 and sets `Backlog`
+- `taskflow-project-automation` moves linked Issues to `In Progress` when a PR opens or returns to draft
+- `taskflow-project-automation` moves linked Issues to `Review` when a PR is marked ready for review
+- `taskflow-project-automation` moves linked Issues to `Done` on merge
+- `taskflow-project-automation` moves linked Issues back to `Ready` if a PR closes without merge
+
+Manual only:
+
+- moving scoped work from `Backlog` to `Ready`
+- triaging imported TaskFlow work before it becomes `Ready`
 
 If the project adds more maintainers later, re-enable:
 


### PR DESCRIPTION
## Summary
- add Project v2 automation for issue creation and linked PR state transitions
- add a post-merge production deploy workflow for `main`
- document the required repository secrets, vars, and branch-protection expectations

## Linked Issue
- Closes #47

## Verification
- [x] `npm run test:run`
- [x] `npm run test:e2e:smoke`
- [x] Manual check completed if UI or API behavior changed
- [x] `npm run lint`
- [x] `npm run build`
- [ ] `npm run audit` (currently fails on existing `flatted`, `next`, and `undici` advisories already present in the branch baseline)

## Impact
- Affected areas: GitHub workflow automation, production deploy configuration, delivery docs
- Breaking changes: none
- Follow-up work: configure `PROJECTV2_TOKEN`, `GH_PROJECTV2_NUMBER`, `VERCEL_TOKEN`, `VERCEL_ORG_ID`, and `VERCEL_PROJECT_ID` in the repository settings
