### PR TITLE
Fix dashboard task deep links into the board modal

### DIFF
--- a/src/app/(dashboard)/projects/[projectId]/board/page.test.tsx
+++ b/src/app/(dashboard)/projects/[projectId]/board/page.test.tsx
@@ -1,0 +1,135 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import BoardPage from './page';
+import { useBoard } from '@/hooks/useBoard';
+import { useProject } from '@/hooks/useProjects';
+import { useAuthStore } from '@/stores/authStore';
+
+const replace = vi.fn();
+let searchParams = new URLSearchParams();
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ projectId: 'project-1' }),
+  usePathname: () => '/projects/project-1/board',
+  useRouter: () => ({ replace }),
+  useSearchParams: () => searchParams,
+}));
+
+vi.mock('@/hooks/useBoard', () => ({
+  useBoard: vi.fn(),
+}));
+
+vi.mock('@/hooks/useProjects', () => ({
+  useProject: vi.fn(),
+}));
+
+vi.mock('@/stores/authStore', () => ({
+  useAuthStore: vi.fn(),
+}));
+
+vi.mock('@/components/board/BoardView', () => ({
+  BoardView: ({ onTaskClick }: { onTaskClick: (taskId: string) => void }) => (
+    <button onClick={() => onTaskClick('task-1')}>open task 1</button>
+  ),
+}));
+
+vi.mock('@/components/board/BoardFilterBar', () => ({
+  BoardFilterBar: () => <div>filters</div>,
+}));
+
+vi.mock('@/components/board/ProjectUrlsBar', () => ({
+  ProjectUrlsBar: () => <div>urls</div>,
+}));
+
+vi.mock('@/components/task/TaskDetailModal', () => ({
+  TaskDetailModal: ({
+    task,
+    isOpen,
+    onClose,
+  }: {
+    task: { id: string; title: string } | null;
+    isOpen: boolean;
+    onClose: () => void;
+  }) => (
+    <div>
+      <div data-testid="modal-state">{isOpen ? 'open' : 'closed'}</div>
+      <div data-testid="modal-task">{task?.title ?? 'none'}</div>
+      <button onClick={onClose}>close modal</button>
+    </div>
+  ),
+}));
+
+const mockedUseBoard = vi.mocked(useBoard);
+const mockedUseProject = vi.mocked(useProject);
+const mockedUseAuthStore = vi.mocked(useAuthStore);
+
+const tasks = [
+  {
+    id: 'task-1',
+    title: 'First task',
+  },
+  {
+    id: 'task-2',
+    title: 'Second task',
+  },
+];
+
+describe('BoardPage', () => {
+  beforeEach(() => {
+    searchParams = new URLSearchParams();
+    replace.mockReset();
+
+    mockedUseBoard.mockReturnValue({
+      lists: [],
+      tasks: tasks as never,
+      labels: [],
+      editTask: vi.fn(),
+      removeTask: vi.fn(),
+      duplicateTask: vi.fn(),
+    } as ReturnType<typeof useBoard>);
+
+    mockedUseProject.mockReturnValue({
+      project: { urls: [] },
+      update: vi.fn(),
+    } as ReturnType<typeof useProject>);
+
+    mockedUseAuthStore.mockReturnValue({
+      user: { id: 'user-1' },
+    } as ReturnType<typeof useAuthStore>);
+  });
+
+  it('opens the task modal from the task query parameter', () => {
+    searchParams = new URLSearchParams('task=task-2');
+
+    render(<BoardPage />);
+
+    expect(screen.getByTestId('modal-state')).toHaveTextContent('open');
+    expect(screen.getByTestId('modal-task')).toHaveTextContent('Second task');
+  });
+
+  it('ignores unknown task ids from the query parameter', () => {
+    searchParams = new URLSearchParams('task=missing-task');
+
+    render(<BoardPage />);
+
+    expect(screen.getByTestId('modal-state')).toHaveTextContent('closed');
+    expect(screen.getByTestId('modal-task')).toHaveTextContent('none');
+  });
+
+  it('syncs board clicks and modal close events back to the URL', async () => {
+    const user = userEvent.setup();
+
+    render(<BoardPage />);
+
+    await user.click(screen.getByRole('button', { name: 'open task 1' }));
+
+    expect(replace).toHaveBeenCalledWith('/projects/project-1/board?task=task-1', { scroll: false });
+
+    await user.click(screen.getByRole('button', { name: 'close modal' }));
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenLastCalledWith('/projects/project-1/board', { scroll: false });
+    });
+  });
+});

--- a/src/app/(dashboard)/projects/[projectId]/board/page.tsx
+++ b/src/app/(dashboard)/projects/[projectId]/board/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useCallback } from 'react';
-import { useParams } from 'next/navigation';
+import { useParams, usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { BoardView } from '@/components/board/BoardView';
 import { BoardFilterBar, type BoardFilters } from '@/components/board/BoardFilterBar';
 import { ProjectUrlsBar } from '@/components/board/ProjectUrlsBar';
@@ -13,12 +13,15 @@ import type { ProjectUrl } from '@/types';
 
 export default function BoardPage() {
   const params = useParams();
+  const pathname = usePathname();
+  const router = useRouter();
+  const searchParams = useSearchParams();
   const projectId = params.projectId as string;
   const { user } = useAuthStore();
   const { lists, tasks, labels, editTask, removeTask, duplicateTask } = useBoard(projectId);
   const { project, update: updateProject } = useProject(projectId);
+  const selectedTaskId = searchParams.get('task');
 
-  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [filters, setFilters] = useState<BoardFilters>({
     keyword: '',
     labelIds: new Set(),
@@ -30,38 +33,55 @@ export default function BoardPage() {
     ? tasks.find((t) => t.id === selectedTaskId) || null
     : null;
 
+  const syncTaskQuery = useCallback(
+    (taskId: string | null) => {
+      const nextParams = new URLSearchParams(searchParams.toString());
+
+      if (taskId) {
+        nextParams.set('task', taskId);
+      } else {
+        nextParams.delete('task');
+      }
+
+      const nextQuery = nextParams.toString();
+      const nextUrl = nextQuery ? `${pathname}?${nextQuery}` : pathname;
+      router.replace(nextUrl, { scroll: false });
+    },
+    [pathname, router, searchParams]
+  );
+
   const handleTaskClick = useCallback((taskId: string) => {
-    setSelectedTaskId(taskId);
-  }, []);
+    syncTaskQuery(taskId);
+  }, [syncTaskQuery]);
 
   const handleCloseModal = useCallback(() => {
-    setSelectedTaskId(null);
-  }, []);
+    syncTaskQuery(null);
+  }, [syncTaskQuery]);
 
   const handleUpdateTask = useCallback(
     (data: Parameters<typeof editTask>[1]) => {
-      if (selectedTaskId) {
-        editTask(selectedTaskId, data);
+      if (selectedTask) {
+        editTask(selectedTask.id, data);
       }
     },
-    [selectedTaskId, editTask]
+    [selectedTask, editTask]
   );
 
   const handleDeleteTask = useCallback(() => {
-    if (selectedTaskId) {
-      removeTask(selectedTaskId);
-      setSelectedTaskId(null);
+    if (selectedTask) {
+      removeTask(selectedTask.id);
+      syncTaskQuery(null);
     }
-  }, [selectedTaskId, removeTask]);
+  }, [selectedTask, removeTask, syncTaskQuery]);
 
   const handleDuplicateTask = useCallback(async () => {
-    if (selectedTaskId && user) {
-      const newTaskId = await duplicateTask(selectedTaskId, user.id);
+    if (selectedTask && user) {
+      const newTaskId = await duplicateTask(selectedTask.id, user.id);
       if (newTaskId) {
-        setSelectedTaskId(newTaskId); // Open the new task
+        syncTaskQuery(newTaskId);
       }
     }
-  }, [selectedTaskId, user, duplicateTask]);
+  }, [selectedTask, user, duplicateTask, syncTaskQuery]);
 
   // URL handlers
   const handleAddUrl = useCallback(
@@ -118,7 +138,7 @@ export default function BoardPage() {
         lists={lists}
         labels={labels}
         allTasks={tasks}
-        isOpen={!!selectedTaskId}
+        isOpen={!!selectedTask}
         onClose={handleCloseModal}
         onUpdate={handleUpdateTask}
         onDelete={handleDeleteTask}


### PR DESCRIPTION
## Summary
- make the board page treat `?task=` as the source of truth for the selected task modal
- sync board clicks, close actions, and duplicate actions back into the URL
- add coverage for valid deep links, invalid task ids, and URL synchronization

## Verification
- npm run audit
- npm run lint
- npm run test:run
- npm run build
- npm run test:e2e:smoke

Closes #55
