### PR TITLE
Cap project header height on wide screens

### DIFF
--- a/src/app/(dashboard)/projects/[projectId]/layout.test.tsx
+++ b/src/app/(dashboard)/projects/[projectId]/layout.test.tsx
@@ -51,7 +51,7 @@ const project: Project = {
 };
 
 describe('ProjectLayout', () => {
-  it('renders the project header banner with the same 5:1 aspect ratio used in the cropper', () => {
+  it('renders the project header banner with a bounded max height for wide screens', () => {
     mockedUseProject.mockReturnValue({
       project,
       isLoading: false,
@@ -64,10 +64,12 @@ describe('ProjectLayout', () => {
     );
 
     expect(screen.getByTestId('project-header-banner')).toHaveClass('aspect-[5/1]');
+    expect(screen.getByTestId('project-header-banner')).toHaveClass('max-h-[240px]');
+    expect(screen.getByTestId('project-header-banner')).toHaveClass('sm:max-h-[260px]');
     expect(screen.getByAltText('TaskFlow header')).toBeInTheDocument();
   });
 
-  it('keeps the same banner ratio when no header image is configured', () => {
+  it('keeps the same bounded header sizing when no header image is configured', () => {
     mockedUseProject.mockReturnValue({
       project: {
         ...project,
@@ -83,6 +85,8 @@ describe('ProjectLayout', () => {
     );
 
     expect(screen.getByTestId('project-header-banner')).toHaveClass('aspect-[5/1]');
+    expect(screen.getByTestId('project-header-banner')).toHaveClass('max-h-[240px]');
+    expect(screen.getByTestId('project-header-banner')).toHaveClass('sm:max-h-[260px]');
     expect(screen.queryByAltText('TaskFlow header')).not.toBeInTheDocument();
   });
 });

--- a/src/app/(dashboard)/projects/[projectId]/layout.tsx
+++ b/src/app/(dashboard)/projects/[projectId]/layout.tsx
@@ -66,7 +66,7 @@ export default function ProjectLayout({
         {/* Header Image or Colored Banner */}
         <div
           data-testid="project-header-banner"
-          className="relative aspect-[5/1] w-full overflow-hidden rounded-lg"
+          className="relative aspect-[5/1] max-h-[240px] w-full overflow-hidden rounded-lg sm:max-h-[260px]"
           style={{
             backgroundColor: project.headerImageUrl ? undefined : `${project.color}30`,
           }}


### PR DESCRIPTION
## Summary
- add a max-height cap to the project header banner so ultra-wide viewports do not let it dominate the screen
- keep the existing 5:1 banner ratio behavior while bounding the rendered height
- update the layout test to cover the bounded header sizing

## Verification
- npm run lint
- npm run test:run
- npm run build
- npm run test:e2e:smoke
- npm run audit  *(currently fails on existing dependency advisories in `next`, `undici`, and `flatted`, unrelated to this UI change)*

Closes #53
