### PR TITLE
Fix PDF attachment preview CSP

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,5 @@
 import type { NextConfig } from "next";
+import { buildContentSecurityPolicy } from "./src/lib/security/contentSecurityPolicy";
 
 const nextConfig: NextConfig = {
   env: {
@@ -35,17 +36,7 @@ const nextConfig: NextConfig = {
           },
           {
             key: "Content-Security-Policy",
-            value: [
-              "default-src 'self'",
-              "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://apis.google.com",
-              "style-src 'self' 'unsafe-inline'",
-              "img-src 'self' data: blob: https://*.googleusercontent.com https://*.googleapis.com https://firebasestorage.googleapis.com",
-              "font-src 'self'",
-              "connect-src 'self' https://*.googleapis.com https://*.firebaseio.com https://*.cloudfunctions.net wss://*.firebaseio.com https://api.openai.com https://api.anthropic.com https://generativelanguage.googleapis.com https://firebasestorage.googleapis.com",
-              "frame-src 'self' https://*.firebaseapp.com https://accounts.google.com",
-              "object-src 'none'",
-              "base-uri 'self'",
-            ].join("; "),
+            value: buildContentSecurityPolicy(),
           },
           {
             key: "X-Content-Type-Options",

--- a/src/lib/security/contentSecurityPolicy.test.ts
+++ b/src/lib/security/contentSecurityPolicy.test.ts
@@ -1,0 +1,11 @@
+import { buildContentSecurityPolicy } from './contentSecurityPolicy';
+
+describe('buildContentSecurityPolicy', () => {
+  it('allows Firebase Storage assets to be embedded in frames', () => {
+    const policy = buildContentSecurityPolicy();
+
+    expect(policy).toContain(
+      "frame-src 'self' https://*.firebaseapp.com https://accounts.google.com https://firebasestorage.googleapis.com"
+    );
+  });
+});

--- a/src/lib/security/contentSecurityPolicy.ts
+++ b/src/lib/security/contentSecurityPolicy.ts
@@ -1,0 +1,15 @@
+export const CONTENT_SECURITY_POLICY_DIRECTIVES = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://apis.google.com",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob: https://*.googleusercontent.com https://*.googleapis.com https://firebasestorage.googleapis.com",
+  "font-src 'self'",
+  "connect-src 'self' https://*.googleapis.com https://*.firebaseio.com https://*.cloudfunctions.net wss://*.firebaseio.com https://api.openai.com https://api.anthropic.com https://generativelanguage.googleapis.com https://firebasestorage.googleapis.com",
+  "frame-src 'self' https://*.firebaseapp.com https://accounts.google.com https://firebasestorage.googleapis.com",
+  "object-src 'none'",
+  "base-uri 'self'",
+] as const;
+
+export function buildContentSecurityPolicy(): string {
+  return CONTENT_SECURITY_POLICY_DIRECTIVES.join('; ');
+}


### PR DESCRIPTION
## Summary

- allow Firebase Storage download URLs in `frame-src` so task/comment PDF previews can render inside the app
- extract the CSP string builder into a small helper and add a regression test for the Firebase Storage frame allowlist

## Linked Issue

- Closes #58
- Required for Project v2 automation

## Verification

- [x] `npm run test:run`
- [x] `npm run test:e2e:smoke`
- [ ] Manual check completed if UI or API behavior changed
- [x] `npm run lint -- next.config.ts src/lib/security/contentSecurityPolicy.ts src/lib/security/contentSecurityPolicy.test.ts`
- [x] `npm run build`

## Impact

- Affected areas: task attachment preview, comment attachment preview, Next.js security headers
- Breaking changes: none
- Follow-up work: none
