### PR TITLE
fix: settings scroll and add-list button position

### DIFF
--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -126,7 +126,7 @@ export default function DashboardLayout({
           <Sidebar />
           <main
             className={cn(
-              'flex min-h-0 flex-1 flex-col overflow-hidden bg-gray-50 p-4 lg:ml-0 lg:p-6',
+              'flex min-h-0 flex-1 flex-col overflow-y-auto bg-gray-50 p-4 lg:ml-0 lg:p-6',
               isSidebarOpen && (isSidebarCollapsed ? 'ml-16' : 'ml-64')
             )}
           >

--- a/src/components/board/BoardView.tsx
+++ b/src/components/board/BoardView.tsx
@@ -440,7 +440,7 @@ export function BoardView({ projectId, onTaskClick, filters }: BoardViewProps) {
           </SortableContext>
 
           {/* Add List */}
-          <div className="flex w-72 flex-shrink-0">
+          <div className="flex w-72 flex-shrink-0 self-start">
           {isAddingList ? (
             <div className="w-full rounded-lg bg-gray-100 p-3">
               <Input

--- a/src/components/board/BoardView.tsx
+++ b/src/components/board/BoardView.tsx
@@ -492,7 +492,7 @@ export function BoardView({ projectId, onTaskClick, filters }: BoardViewProps) {
           ) : (
             <Button
               variant="outline"
-              className="h-auto w-full justify-start border-dashed py-6"
+              className="h-auto w-full self-start justify-start border-dashed py-3"
               onClick={() => setIsAddingList(true)}
             >
               <Plus className="mr-2 h-4 w-4" />


### PR DESCRIPTION
## Summary
- 設定画面 (`/settings`, `/settings/ai`, `/settings/api-keys`, `/profile`) でコンテンツが画面より長いとスクロール不可だった件を修正。`(dashboard)/layout.tsx` の `main` を `overflow-hidden` → `overflow-y-auto` に変更
- ボード画面の「+ リストを追加」ボタンが、隣リストの伸長に引き伸ばされて縦中央に見える問題を修正。`self-start` を当てて上端固定に、`py-6` → `py-3` でコンパクト化

## Notes
- ボード/ガントのページは内部で `h-full overflow-hidden` を持ち、独自のスクロール領域を持つため、`main` の縦スクロール許可による影響はなし
- 既存の単体テスト・E2Eスモークすべてグリーン

## Test plan
- [x] `npm run lint`
- [x] `npm run test:run` (147 tests passed)
- [x] `npm run build`
- [x] `npm run test:e2e:smoke` (3 tests passed)
- [ ] `/settings` を縦長コンテンツで開いてスクロールできることを確認
- [ ] ボード画面で「+ リストを追加」がカラム上部に表示されることを確認
- [ ] ボード/ガントの既存スクロール挙動に変化がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)