### PR TITLE
fix: enable scroll for settings/profile pages

### DIFF
--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -126,7 +126,7 @@ export default function DashboardLayout({
           <Sidebar />
           <main
             className={cn(
-              'flex min-h-0 flex-1 flex-col overflow-hidden bg-gray-50 p-4 lg:ml-0 lg:p-6',
+              'flex min-h-0 flex-1 flex-col overflow-y-auto bg-gray-50 p-4 lg:ml-0 lg:p-6',
               isSidebarOpen && (isSidebarCollapsed ? 'ml-16' : 'ml-64')
             )}
           >


### PR DESCRIPTION
## Summary
設定画面 (`/settings`, `/settings/ai`, `/settings/api-keys`, `/profile`) でコンテンツが画面より長いとスクロール不可だった件を修正。`(dashboard)/layout.tsx` の `main` を `overflow-hidden` → `overflow-y-auto` に変更。

ボード/ガントは内部で `h-full overflow-hidden` の独自スクロール構造を持つため影響なし。

## Background
PR #64 で 2026-05-08 のマージを全 revert して #57 状態に戻した後の、段階的再投入の 1本目。

## Test plan
- [x] `npm run lint`
- [x] `npm run test:run` (147 tests passed)
- [x] `npm run build`
- [x] `npm run test:e2e:smoke` (3 tests passed)
- [ ] マージ → 本番デプロイ → 設定画面でスクロールできることを確認
- [ ] ボード／ガントの既存スクロール挙動に変化がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)