### PR TITLE
fix(board): place add-list button at the top of its column

### DIFF
--- a/src/components/board/BoardView.tsx
+++ b/src/components/board/BoardView.tsx
@@ -440,7 +440,7 @@ export function BoardView({ projectId, onTaskClick, filters }: BoardViewProps) {
           </SortableContext>
 
           {/* Add List */}
-          <div className="flex w-72 flex-shrink-0">
+          <div className="flex w-72 flex-shrink-0 self-start">
           {isAddingList ? (
             <div className="w-full rounded-lg bg-gray-100 p-3">
               <Input
@@ -492,7 +492,7 @@ export function BoardView({ projectId, onTaskClick, filters }: BoardViewProps) {
           ) : (
             <Button
               variant="outline"
-              className="h-auto w-full justify-start border-dashed py-6"
+              className="h-auto w-full justify-start border-dashed py-3"
               onClick={() => setIsAddingList(true)}
             >
               <Plus className="mr-2 h-4 w-4" />


### PR DESCRIPTION
## Summary
ボード画面の「+ リストを追加」ボタンが、隣の長いリストと同じ高さに引き伸ばされて縦中央に表示される問題を修正。

- `<div className="flex w-72 flex-shrink-0">` に `self-start` を追加 → 列自体が引き伸ばされなくなる
- ボタン側を `py-6` → `py-3` でコンパクトに

## Background
PR #64 全 revert 後の段階的再投入 2本目（前回 #61 のレビューで指摘された「self-start を Button ではなく外側wrapperに当てるべき」を反映済み）。

## Test plan
- [x] `npm run lint`
- [x] `npm run test:run` (147 tests passed)
- [x] `npm run build`
- [x] `npm run test:e2e:smoke` (3 tests passed)
- [ ] マージ → 本番でボード画面の「+ リストを追加」がカラム上端に表示されることを確認
- [ ] タスクが多いリストの隣でも引き伸ばされていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)