### PR TITLE
feat(ai): make CompanionAI chat panel draggable

### DIFF
--- a/src/components/ai/CompanionAI.tsx
+++ b/src/components/ai/CompanionAI.tsx
@@ -83,10 +83,107 @@ export function CompanionAI({ projectId }: CompanionAIProps) {
   const [showToolConfirm, setShowToolConfirm] = useState(false);
   const [pendingTools, setPendingTools] = useState<ToolCall[] | null>(null);
   const [projectAccessError, setProjectAccessError] = useState<string | null>(null);
+  const [panelPosition, setPanelPosition] = useState<{ x: number; y: number } | null>(() => {
+    if (typeof window === 'undefined') return null;
+    try {
+      const stored = localStorage.getItem('companionAIPanelPosition');
+      return stored ? (JSON.parse(stored) as { x: number; y: number }) : null;
+    } catch {
+      return null;
+    }
+  });
 
   const panelRef = useRef<HTMLDivElement>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const projectAccessRequestedRef = useRef(false);
+  const dragStateRef = useRef<{
+    startClientX: number;
+    startClientY: number;
+    startPosX: number;
+    startPosY: number;
+  } | null>(null);
+  const latestPositionRef = useRef<{ x: number; y: number } | null>(panelPosition);
+
+  const handlePanelDragStart = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    if ((e.target as HTMLElement).closest('button, input, textarea, a')) return;
+    if (!panelRef.current) return;
+    const rect = panelRef.current.getBoundingClientRect();
+    dragStateRef.current = {
+      startClientX: e.clientX,
+      startClientY: e.clientY,
+      startPosX: rect.left,
+      startPosY: rect.top,
+    };
+    document.body.style.userSelect = 'none';
+    e.preventDefault();
+  }, []);
+
+  useEffect(() => {
+    const clamp = (x: number, y: number) => {
+      const w = panelRef.current?.offsetWidth ?? 420;
+      const h = panelRef.current?.offsetHeight ?? 600;
+      const maxX = Math.max(0, window.innerWidth - w);
+      const maxY = Math.max(0, window.innerHeight - h);
+      return {
+        x: Math.min(Math.max(0, x), maxX),
+        y: Math.min(Math.max(0, y), maxY),
+      };
+    };
+
+    const onMouseMove = (event: MouseEvent) => {
+      if (!dragStateRef.current) return;
+      const { startClientX, startClientY, startPosX, startPosY } = dragStateRef.current;
+      const next = clamp(
+        startPosX + (event.clientX - startClientX),
+        startPosY + (event.clientY - startClientY)
+      );
+      latestPositionRef.current = next;
+      setPanelPosition(next);
+    };
+
+    const finishDrag = () => {
+      if (!dragStateRef.current) return;
+      dragStateRef.current = null;
+      document.body.style.userSelect = '';
+      const finalPos = latestPositionRef.current;
+      if (finalPos) {
+        try {
+          localStorage.setItem('companionAIPanelPosition', JSON.stringify(finalPos));
+        } catch {
+          // localStorage may be unavailable (private mode, quota); ignore
+        }
+      }
+    };
+
+    window.addEventListener('mousemove', onMouseMove);
+    window.addEventListener('mouseup', finishDrag);
+    window.addEventListener('blur', finishDrag);
+    return () => {
+      window.removeEventListener('mousemove', onMouseMove);
+      window.removeEventListener('mouseup', finishDrag);
+      window.removeEventListener('blur', finishDrag);
+    };
+  }, []);
+
+  useEffect(() => {
+    const onResize = () => {
+      setPanelPosition((prev) => {
+        if (!prev) return prev;
+        const w = panelRef.current?.offsetWidth ?? 420;
+        const h = panelRef.current?.offsetHeight ?? 600;
+        const maxX = Math.max(0, window.innerWidth - w);
+        const maxY = Math.max(0, window.innerHeight - h);
+        const x = Math.min(Math.max(0, prev.x), maxX);
+        const y = Math.min(Math.max(0, prev.y), maxY);
+        if (x === prev.x && y === prev.y) return prev;
+        const next = { x, y };
+        latestPositionRef.current = next;
+        return next;
+      });
+    };
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
 
   useEffect(() => {
     projectAccessRequestedRef.current = false;
@@ -531,10 +628,21 @@ export function CompanionAI({ projectId }: CompanionAIProps) {
       {isOpen && (
         <div
           ref={panelRef}
-          className="fixed bottom-24 right-6 z-50 flex h-[600px] w-[420px] flex-col overflow-hidden rounded-lg border bg-background shadow-xl"
+          className={cn(
+            'fixed z-50 flex h-[600px] w-[420px] flex-col overflow-hidden rounded-lg border bg-background shadow-xl',
+            !panelPosition && 'bottom-24 right-6'
+          )}
+          style={
+            panelPosition
+              ? { left: panelPosition.x, top: panelPosition.y }
+              : undefined
+          }
         >
-          {/* Header */}
-          <div className="flex items-center justify-between border-b px-4 py-3">
+          {/* Header (drag handle) */}
+          <div
+            className="flex cursor-move select-none items-center justify-between border-b px-4 py-3"
+            onMouseDown={handlePanelDragStart}
+          >
             <div className="flex items-center gap-2 min-w-0">
               <MessageCircle className="h-5 w-5 shrink-0" />
               <span className="truncate font-medium">


### PR DESCRIPTION
## Summary
サポートAIのチャットパネルを画面右下固定からドラッグ可能に変更。チャット中に下のボード／ガント／タスクが見えなくなる問題を解消。

## Changes
- ヘッダー領域を `cursor-move` のドラッグハンドル化、`closest('button, input, textarea, a')` 上では発火しない（既存ボタン操作と両立）
- window レベルの `mousemove` 追従、`mouseup` と **`blur`** の両方でドラッグ終了（focus を失った時の急跳び防止）
- ドラッグ中は `document.body.style.userSelect = 'none'` で他要素のテキスト選択を抑制
- ドラッグ中・ウィンドウリサイズ時にビューポート内へクランプ
- 位置は `localStorage.companionAIPanelPosition` に **mouseup 時のみ** 永続化（mousemove 毎の書き込み回避）。未設定時は従来の `bottom-24 right-6` にアンカー

## Background
PR #64 全 revert 後の段階的再投入 3本目。前回 #62 のレビューで指摘された3点（blur時の状態クリア、document.body の userSelect、localStorage 書き込み頻度）を最初から実装に組み込み済み。

## Test plan
- [x] `npm run lint`
- [x] `npm run test:run` (147 tests passed)
- [x] `npm run build`
- [x] `npm run test:e2e:smoke` (3 tests passed)
- [ ] マージ → 本番でパネルヘッダーをドラッグして任意位置に移動できる
- [ ] ヘッダー内の「履歴」「設定」ボタンが従来通り動作する
- [ ] ページ遷移／再読込後も最後に置いた位置が維持される
- [ ] ウィンドウを縮小したときパネルが画面外に出ない
- [ ] ドラッグ中にタブを切り替えて戻ってもパネルが急跳びしない

## Notes
- タッチデバイス対応（pointer events / touchstart 系）はスコープ外、follow-up で別 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)