### PR TITLE
feat(auth): add public demo login button + seed script

### DIFF
--- a/e2e/auth-smoke.spec.ts
+++ b/e2e/auth-smoke.spec.ts
@@ -9,6 +9,13 @@ test.describe('Authentication Smoke', () => {
     await expect(page.getByTestId('test-login')).toHaveCount(0);
   });
 
+  test('shows the demo login button when NEXT_PUBLIC_DEMO_PASSWORD is set', async ({ page }) => {
+    await page.goto('/login');
+
+    await expect(page.getByTestId('demo-login')).toBeVisible();
+    await expect(page.getByText('デモを試す（ログイン不要）')).toBeVisible();
+  });
+
   test('redirects protected routes to login when unauthenticated', async ({ page }) => {
     await page.goto('/projects');
 

--- a/e2e/demo-login.spec.ts
+++ b/e2e/demo-login.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Demo Login Button', () => {
+  test('is visible on the login page when configured', async ({ page }) => {
+    await page.goto('/login');
+
+    const demoButton = page.getByTestId('demo-login');
+    await expect(demoButton).toBeVisible();
+    await expect(demoButton).toContainText('デモを試す');
+    await expect(
+      page.getByText('サンプルプロジェクトで機能を体験できます')
+    ).toBeVisible();
+  });
+
+  test('does not crash the page when clicked with smoke firebase config', async ({ page }) => {
+    // The smoke environment uses placeholder Firebase credentials, so the actual
+    // sign-in call is expected to fail at the network/auth layer. We just want to
+    // ensure the click handler stays defensive and the user remains on /login.
+    await page.goto('/login');
+
+    await page.getByTestId('demo-login').click();
+    await page.waitForTimeout(1500);
+
+    await expect(page).toHaveURL(/\/login$/);
+    await expect(page.getByTestId('demo-login')).toBeVisible();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "audit": "npm audit --omit=optional --audit-level=high",
     "deps:report": "node ./scripts/dependency-health-report.mjs",
+    "seed:demo": "node --env-file-if-exists=.env.local ./scripts/seed-demo.mjs",
     "lint": "eslint src e2e scripts playwright.config.ts eslint.config.mjs next.config.ts",
     "test": "vitest",
     "test:run": "vitest run",

--- a/scripts/run-playwright-smoke.mjs
+++ b/scripts/run-playwright-smoke.mjs
@@ -12,6 +12,10 @@ const baseEnv = {
     process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID ?? '1234567890',
   NEXT_PUBLIC_FIREBASE_APP_ID:
     process.env.NEXT_PUBLIC_FIREBASE_APP_ID ?? '1:1234567890:web:abcdef123456',
+  NEXT_PUBLIC_DEMO_EMAIL:
+    process.env.NEXT_PUBLIC_DEMO_EMAIL ?? 'demo@1000ri.jp',
+  NEXT_PUBLIC_DEMO_PASSWORD:
+    process.env.NEXT_PUBLIC_DEMO_PASSWORD ?? 'smoke-demo-password',
   NEXT_TELEMETRY_DISABLED: process.env.NEXT_TELEMETRY_DISABLED ?? '1',
 };
 
@@ -50,6 +54,11 @@ function runPlaywright(specPath, envOverrides) {
 
 async function main() {
   await runPlaywright('e2e/auth-smoke.spec.ts', {
+    NEXT_PUBLIC_ENABLE_TEST_AUTH: 'false',
+    NEXT_PUBLIC_E2E_MOCK_AUTH: 'false',
+  });
+
+  await runPlaywright('e2e/demo-login.spec.ts', {
     NEXT_PUBLIC_ENABLE_TEST_AUTH: 'false',
     NEXT_PUBLIC_E2E_MOCK_AUTH: 'false',
   });

--- a/scripts/seed-demo.mjs
+++ b/scripts/seed-demo.mjs
@@ -1,0 +1,301 @@
+#!/usr/bin/env node
+/**
+ * Seed the shared demo user with a clean set of sample projects/lists/tasks.
+ *
+ * Idempotent: removes any existing projects owned by the demo user before
+ * recreating them, so re-running this script always produces the same result.
+ *
+ * Required env vars:
+ *   - FIREBASE_SERVICE_ACCOUNT_KEY   (JSON string for Firebase Admin SDK)
+ *   - NEXT_PUBLIC_FIREBASE_PROJECT_ID
+ *   - NEXT_PUBLIC_DEMO_EMAIL         (defaults to demo@1000ri.jp)
+ *   - NEXT_PUBLIC_DEMO_PASSWORD      (must match the value exposed to the client)
+ *
+ * Recommended invocation (Node 20+):
+ *   node --env-file-if-exists=.env.local ./scripts/seed-demo.mjs
+ */
+
+import { initializeApp, cert, applicationDefault, getApps } from 'firebase-admin/app';
+import { getAuth } from 'firebase-admin/auth';
+import { getFirestore, FieldValue } from 'firebase-admin/firestore';
+
+const DEMO_EMAIL = process.env.NEXT_PUBLIC_DEMO_EMAIL ?? 'demo@1000ri.jp';
+const DEMO_PASSWORD = process.env.NEXT_PUBLIC_DEMO_PASSWORD;
+const DEMO_DISPLAY_NAME = 'デモユーザー';
+const PROJECT_ID = process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID;
+
+if (!DEMO_PASSWORD) {
+  console.error('NEXT_PUBLIC_DEMO_PASSWORD is required.');
+  process.exit(1);
+}
+if (!PROJECT_ID) {
+  console.error('NEXT_PUBLIC_FIREBASE_PROJECT_ID is required.');
+  process.exit(1);
+}
+
+const DEFAULT_LABELS = [
+  { name: '高優先', color: '#ef4444' },
+  { name: '中優先', color: '#f59e0b' },
+  { name: '低優先', color: '#6b7280' },
+  { name: 'バグ', color: '#dc2626' },
+  { name: '機能', color: '#3b82f6' },
+];
+
+const DEFAULT_TAGS = [
+  { name: '進行中', color: '#3b82f6' },
+  { name: '指示待ち', color: '#f97316' },
+  { name: '完了', color: '#22c55e' },
+  { name: '確認中', color: '#ef4444' },
+];
+
+const PROJECT_SPECS = [
+  {
+    name: 'Webサイトリニューアル',
+    description: 'コーポレートサイトの全面リニューアルプロジェクト',
+    icon: '🌐',
+    color: '#3b82f6',
+    lists: [
+      { name: 'ToDo', color: '#64748b' },
+      { name: '進行中', color: '#3b82f6' },
+      { name: 'レビュー', color: '#f59e0b' },
+      { name: '完了', color: '#22c55e' },
+    ],
+    tasks: [
+      { listIdx: 0, title: 'デザインカンプ作成', priority: 'high', daysFromNow: 3 },
+      { listIdx: 0, title: 'ワイヤーフレーム確定', priority: 'medium', daysFromNow: 5 },
+      { listIdx: 0, title: 'コンテンツ移行計画', priority: 'low', daysFromNow: 7 },
+      { listIdx: 1, title: 'トップページ実装', priority: 'high', daysFromNow: 10 },
+      { listIdx: 1, title: 'お問い合わせフォーム', priority: 'medium', daysFromNow: 12 },
+      { listIdx: 2, title: 'SEO設定確認', priority: 'medium', daysFromNow: 14 },
+      { listIdx: 3, title: '要件定義', priority: 'high', daysFromNow: -7, isCompleted: true },
+    ],
+  },
+  {
+    name: 'モバイルアプリv2',
+    description: 'iOS/Android アプリの大型バージョンアップ',
+    icon: '📱',
+    color: '#8b5cf6',
+    lists: [
+      { name: 'バックログ', color: '#64748b' },
+      { name: '今スプリント', color: '#3b82f6' },
+      { name: 'QA', color: '#f59e0b' },
+      { name: 'リリース済み', color: '#22c55e' },
+    ],
+    tasks: [
+      { listIdx: 0, title: 'プッシュ通知設計', priority: 'medium', daysFromNow: 21 },
+      { listIdx: 0, title: 'オフラインモード仕様', priority: 'low', daysFromNow: 28 },
+      { listIdx: 1, title: 'ログイン画面リデザイン', priority: 'high', daysFromNow: 4 },
+      { listIdx: 1, title: 'ダッシュボードAPI連携', priority: 'high', daysFromNow: 6 },
+      { listIdx: 1, title: 'プロフィール編集機能', priority: 'medium', daysFromNow: 8 },
+      { listIdx: 2, title: 'ログイン周りの回帰テスト', priority: 'medium', daysFromNow: 2 },
+      { listIdx: 3, title: 'v1.9 hotfix', priority: 'high', daysFromNow: -3, isCompleted: true },
+    ],
+  },
+  {
+    name: '社内オペレーション改善',
+    description: '営業・サポート部門の業務フロー見直し',
+    icon: '⚙️',
+    color: '#22c55e',
+    lists: [
+      { name: '提案中', color: '#64748b' },
+      { name: '実施中', color: '#3b82f6' },
+      { name: '効果測定', color: '#f59e0b' },
+      { name: '完了', color: '#22c55e' },
+    ],
+    tasks: [
+      { listIdx: 0, title: 'CRM 移行調査', priority: 'high', daysFromNow: 14 },
+      { listIdx: 0, title: '問い合わせフォーム改善', priority: 'medium', daysFromNow: 9 },
+      { listIdx: 1, title: '日次レポート自動化', priority: 'medium', daysFromNow: 5 },
+      { listIdx: 1, title: '休暇申請の Slack 統合', priority: 'low', daysFromNow: 11 },
+      { listIdx: 2, title: '新オンボーディング効果測定', priority: 'medium', daysFromNow: 7 },
+      { listIdx: 3, title: '備品発注ワークフロー導入', priority: 'low', daysFromNow: -10, isCompleted: true },
+    ],
+  },
+];
+
+function initAdminApp() {
+  if (getApps().length > 0) {
+    return getApps()[0];
+  }
+  const serviceAccountKey = process.env.FIREBASE_SERVICE_ACCOUNT_KEY;
+  if (serviceAccountKey) {
+    return initializeApp({
+      credential: cert(JSON.parse(serviceAccountKey)),
+      projectId: PROJECT_ID,
+    });
+  }
+  return initializeApp({
+    credential: applicationDefault(),
+    projectId: PROJECT_ID,
+  });
+}
+
+async function ensureDemoUser(auth) {
+  try {
+    const user = await auth.getUserByEmail(DEMO_EMAIL);
+    await auth.updateUser(user.uid, {
+      password: DEMO_PASSWORD,
+      displayName: DEMO_DISPLAY_NAME,
+    });
+    console.log(`Demo user already exists (uid=${user.uid}); password & displayName synced.`);
+    return user.uid;
+  } catch (err) {
+    if (err.code !== 'auth/user-not-found') throw err;
+    const created = await auth.createUser({
+      email: DEMO_EMAIL,
+      password: DEMO_PASSWORD,
+      displayName: DEMO_DISPLAY_NAME,
+      emailVerified: true,
+    });
+    console.log(`Created demo user (uid=${created.uid}).`);
+    return created.uid;
+  }
+}
+
+async function ensureUserDoc(db, uid) {
+  await db.collection('users').doc(uid).set(
+    {
+      displayName: DEMO_DISPLAY_NAME,
+      email: DEMO_EMAIL,
+      photoURL: null,
+      updatedAt: FieldValue.serverTimestamp(),
+      createdAt: FieldValue.serverTimestamp(),
+    },
+    { merge: true }
+  );
+}
+
+async function deleteDocAndSubcollections(docRef) {
+  const subcollections = await docRef.listCollections();
+  for (const sub of subcollections) {
+    const docs = await sub.listDocuments();
+    for (const child of docs) {
+      await deleteDocAndSubcollections(child);
+    }
+  }
+  await docRef.delete();
+}
+
+async function clearExistingDemoProjects(db, uid) {
+  const snap = await db.collection('projects').where('ownerId', '==', uid).get();
+  if (snap.empty) {
+    console.log('No existing demo projects to clear.');
+    return;
+  }
+  console.log(`Clearing ${snap.size} existing demo project(s)...`);
+  for (const doc of snap.docs) {
+    await deleteDocAndSubcollections(doc.ref);
+  }
+}
+
+async function seedProject(db, uid, spec, projectOrder) {
+  const projectRef = db.collection('projects').doc();
+  await projectRef.set({
+    name: spec.name,
+    description: spec.description,
+    icon: spec.icon,
+    color: spec.color,
+    ownerId: uid,
+    memberIds: [uid],
+    isArchived: false,
+    order: projectOrder,
+    createdAt: FieldValue.serverTimestamp(),
+    updatedAt: FieldValue.serverTimestamp(),
+  });
+
+  await projectRef.collection('members').doc(uid).set({
+    userId: uid,
+    role: 'admin',
+    joinedAt: FieldValue.serverTimestamp(),
+  });
+
+  for (const label of DEFAULT_LABELS) {
+    await projectRef.collection('labels').add({
+      ...label,
+      createdAt: FieldValue.serverTimestamp(),
+    });
+  }
+  for (let i = 0; i < DEFAULT_TAGS.length; i++) {
+    await projectRef.collection('tags').add({
+      ...DEFAULT_TAGS[i],
+      order: i,
+      createdAt: FieldValue.serverTimestamp(),
+    });
+  }
+
+  const listIds = [];
+  for (let i = 0; i < spec.lists.length; i++) {
+    const listSpec = spec.lists[i];
+    const listRef = await projectRef.collection('lists').add({
+      projectId: projectRef.id,
+      name: listSpec.name,
+      color: listSpec.color,
+      order: i,
+      autoCompleteOnEnter: listSpec.name === '完了' || listSpec.name === 'リリース済み',
+      autoUncompleteOnExit: false,
+      createdAt: FieldValue.serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+    listIds.push(listRef.id);
+  }
+
+  const now = Date.now();
+  for (let i = 0; i < spec.tasks.length; i++) {
+    const t = spec.tasks[i];
+    const dueDate = new Date(now + t.daysFromNow * 86400000);
+    const completedAt = t.isCompleted ? new Date(now + t.daysFromNow * 86400000) : null;
+    await projectRef.collection('tasks').add({
+      projectId: projectRef.id,
+      listId: listIds[t.listIdx],
+      title: t.title,
+      description: '',
+      order: i,
+      assigneeIds: [uid],
+      labelIds: [],
+      tagIds: [],
+      dependsOnTaskIds: [],
+      priority: t.priority ?? null,
+      startDate: null,
+      dueDate,
+      durationDays: null,
+      isDueDateFixed: false,
+      isCompleted: t.isCompleted ?? false,
+      completedAt,
+      isAbandoned: false,
+      isArchived: false,
+      archivedAt: null,
+      archivedBy: null,
+      createdBy: uid,
+      createdAt: FieldValue.serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+  }
+
+  console.log(
+    `Seeded project "${spec.name}" — ${spec.lists.length} lists, ${spec.tasks.length} tasks.`
+  );
+}
+
+async function main() {
+  const app = initAdminApp();
+  const auth = getAuth(app);
+  const db = getFirestore(app);
+
+  const uid = await ensureDemoUser(auth);
+  await ensureUserDoc(db, uid);
+  await clearExistingDemoProjects(db, uid);
+
+  for (let i = 0; i < PROJECT_SPECS.length; i++) {
+    await seedProject(db, uid, PROJECT_SPECS[i], i);
+  }
+
+  console.log('\nDemo seed completed successfully.');
+  console.log(`  Demo email   : ${DEMO_EMAIL}`);
+  console.log(`  Demo uid     : ${uid}`);
+  console.log(`  Projects     : ${PROJECT_SPECS.length}`);
+}
+
+main().catch((err) => {
+  console.error('Demo seed failed:', err);
+  process.exit(1);
+});

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -6,11 +6,19 @@ import { useAuth } from '@/hooks/useAuth';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
-import { Loader2, FlaskConical } from 'lucide-react';
+import { Loader2, FlaskConical, Sparkles } from 'lucide-react';
 
 export default function LoginPage() {
   const router = useRouter();
-  const { isAuthenticated, isLoading, isTestMode, signIn, signInAsTestUser } = useAuth();
+  const {
+    isAuthenticated,
+    isLoading,
+    isTestMode,
+    isDemoLoginEnabled,
+    signIn,
+    signInAsTestUser,
+    signInAsDemoUser,
+  } = useAuth();
 
   useEffect(() => {
     if (isAuthenticated && !isLoading) {
@@ -33,6 +41,15 @@ export default function LoginPage() {
       router.push('/');
     } catch (error) {
       console.error('Test login failed:', error);
+    }
+  };
+
+  const handleDemoSignIn = async () => {
+    try {
+      await signInAsDemoUser();
+      router.push('/');
+    } catch (error) {
+      console.error('Demo login failed:', error);
     }
   };
 
@@ -83,6 +100,34 @@ export default function LoginPage() {
             </svg>
             Googleでログイン
           </Button>
+
+          {isDemoLoginEnabled && (
+            <>
+              <div className="relative">
+                <div className="absolute inset-0 flex items-center">
+                  <Separator className="w-full" />
+                </div>
+                <div className="relative flex justify-center text-xs uppercase">
+                  <span className="bg-background px-2 text-muted-foreground">
+                    または
+                  </span>
+                </div>
+              </div>
+              <Button
+                onClick={handleDemoSignIn}
+                variant="secondary"
+                className="w-full"
+                size="lg"
+                data-testid="demo-login"
+              >
+                <Sparkles className="mr-2 h-5 w-5" />
+                デモを試す（ログイン不要）
+              </Button>
+              <p className="text-center text-xs text-muted-foreground">
+                サンプルプロジェクトで機能を体験できます
+              </p>
+            </>
+          )}
 
           {isTestMode && (
             <>

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -5,8 +5,10 @@ import { useAuthStore } from '@/stores/authStore';
 import {
   signInWithGoogle,
   signInWithTestUser,
+  signInWithDemoUser,
   signOut as firebaseSignOut,
   isTestMode,
+  isDemoLoginEnabled,
   getUserData,
 } from '@/lib/firebase/auth';
 import { isE2EMockAuthEnabled } from '@/lib/firebase/testMode';
@@ -56,6 +58,22 @@ export function useAuth() {
     }
   }, [setLoading, setFirebaseUser, setUser]);
 
+  // Sign in with the shared demo user (production demo button)
+  const signInAsDemoUser = useCallback(async () => {
+    try {
+      setLoading(true);
+      const fbUser = await signInWithDemoUser();
+      setFirebaseUser(fbUser);
+      const userData = await getUserData(fbUser.uid);
+      setUser(userData);
+    } catch (error) {
+      console.error('Demo sign in error:', error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, [setLoading, setFirebaseUser, setUser]);
+
   // Sign out
   const signOut = useCallback(async () => {
     try {
@@ -80,8 +98,10 @@ export function useAuth() {
     isLoading,
     isAuthenticated,
     isTestMode: isTestMode(),
+    isDemoLoginEnabled: isDemoLoginEnabled(),
     signIn,
     signInAsTestUser,
+    signInAsDemoUser,
     signOut,
   };
 }

--- a/src/lib/firebase/auth.ts
+++ b/src/lib/firebase/auth.ts
@@ -29,9 +29,20 @@ export const TEST_USER = {
   displayName: 'テストユーザー',
 } as const;
 
+// Demo user credentials (production demo button — credentials are public by design)
+export const DEMO_USER_EMAIL =
+  process.env.NEXT_PUBLIC_DEMO_EMAIL ?? 'demo@1000ri.jp';
+const DEMO_USER_PASSWORD = process.env.NEXT_PUBLIC_DEMO_PASSWORD ?? '';
+export const DEMO_USER_DISPLAY_NAME = 'デモユーザー';
+
 // Check if test mode is enabled (only on localhost)
 export function isTestMode(): boolean {
   return isFirebaseTestAuthEnabled();
+}
+
+// Demo login is available whenever the demo password env var is configured.
+export function isDemoLoginEnabled(): boolean {
+  return DEMO_USER_PASSWORD.length > 0;
 }
 
 /**
@@ -92,6 +103,52 @@ export async function signInWithTestUser(): Promise<User> {
       } catch (createError: unknown) {
         // If user already exists with different password, or other error
         console.error('Failed to create test user:', createError);
+        throw createError;
+      }
+    }
+    throw error;
+  }
+}
+
+/**
+ * Sign in with the shared demo user (always available in production).
+ * Auto-creates the Firebase Auth record on first use so the button never dead-ends,
+ * but production setup should run `npm run seed:demo` to populate sample data.
+ */
+export async function signInWithDemoUser(): Promise<User> {
+  if (!isDemoLoginEnabled()) {
+    throw new Error(
+      'デモログインは現在利用できません。NEXT_PUBLIC_DEMO_PASSWORD が設定されていません。'
+    );
+  }
+
+  const auth = getFirebaseAuth();
+
+  try {
+    const result = await signInWithEmailAndPassword(
+      auth,
+      DEMO_USER_EMAIL,
+      DEMO_USER_PASSWORD
+    );
+    await createOrUpdateUser(result.user);
+    return result.user;
+  } catch (error: unknown) {
+    const errorCode =
+      error && typeof error === 'object' && 'code' in error ? error.code : null;
+    if (
+      errorCode === 'auth/user-not-found' ||
+      errorCode === 'auth/invalid-credential'
+    ) {
+      try {
+        const result = await createUserWithEmailAndPassword(
+          auth,
+          DEMO_USER_EMAIL,
+          DEMO_USER_PASSWORD
+        );
+        await createOrUpdateUser(result.user);
+        return result.user;
+      } catch (createError: unknown) {
+        console.error('Failed to create demo user:', createError);
         throw createError;
       }
     }


### PR DESCRIPTION
## Summary
- ログイン画面に「デモを試す（ログイン不要）」ボタンを追加（`NEXT_PUBLIC_DEMO_PASSWORD` が設定されている時のみ表示）。クライアントが手元ですぐ操作できる。
- `signInWithDemoUser` を Firebase auth helper に追加。1000ri.jp ドメイン制限を維持するため `demo@1000ri.jp` を使用、Firestore rules は変更不要。
- `scripts/seed-demo.mjs` を追加。Firebase Admin SDK で demo ユーザーを ensure し、3 プロジェクト × 4 リスト × 6〜7 タスクのサンプルデータを idempotent に再生成する。
- `npm run seed:demo` スクリプトを追加（Node `--env-file-if-exists` を利用）。
- E2E スモークに `demo-login.spec.ts` を追加し、auth-smoke にも可視性アサーションを追加。

## デプロイ後の手順
1. Vercel に環境変数を追加（Production / Preview）:
   - `NEXT_PUBLIC_DEMO_EMAIL=demo@1000ri.jp`
   - `NEXT_PUBLIC_DEMO_PASSWORD=<強めのパスワード>`
2. 再デプロイで本番にボタンが表示される
3. ローカルから `FIREBASE_SERVICE_ACCOUNT_KEY=... npm run seed:demo` を実行して本番 Firestore にデモデータを投入

## Test plan
- [x] `npm run lint`
- [x] `npm run build`（プレースホルダ env で）
- [x] `npm run test:e2e:smoke`（6/6 緑）
- [ ] Vercel デプロイ後、本番 `/login` でデモボタン表示確認
- [ ] デモログイン → ダッシュボード遷移 → サンプルプロジェクト表示確認
- [ ] デモユーザー側で API キー設定が他ユーザーに漏れないか軽く確認（`/settings/ai` 個別保存）

🤖 Generated with [Claude Code](https://claude.com/claude-code)