### PR TITLE
fix(firestore): unblock new users on dashboard (rules + conversations index)

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -60,6 +60,25 @@
         }
       ],
       "density": "SPARSE_ALL"
+    },
+    {
+      "collectionGroup": "conversations",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "projectId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "updatedAt",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "DESCENDING"
+        }
+      ],
+      "density": "SPARSE_ALL"
     }
   ],
   "fieldOverrides": []

--- a/firestore.rules
+++ b/firestore.rules
@@ -141,10 +141,16 @@ service cloud.firestore {
       allow update, delete: if isAllowedUser() && resource.data.userId == request.auth.uid;
     }
 
-    // ユーザーメモ - 本人のみ
+    // ユーザーメモ - 本人のみ。
+    // memoId は uid なので、ドキュメント未作成時でも権限判定できるよう
+    // memoId == request.auth.uid を主条件にし、誤って他ユーザーの memo を
+    // 上書きできないよう resource.data.userId も補助的に検証する。
     match /userMemos/{memoId} {
-      allow read, write: if isAllowedUser() && resource.data.userId == request.auth.uid;
-      allow create: if isAllowedUser();
+      allow read: if isAllowedUser() && memoId == request.auth.uid;
+      allow create: if isAllowedUser() && memoId == request.auth.uid &&
+                       request.resource.data.userId == request.auth.uid;
+      allow update, delete: if isAllowedUser() && memoId == request.auth.uid &&
+                               resource.data.userId == request.auth.uid;
     }
   }
 }


### PR DESCRIPTION
## Summary
新規作成ユーザー（特に今日追加したデモユーザー）がダッシュボードを開くと2種類のエラーが出てプロジェクトが見えない問題の修正。

### 原因と修正

1. **`permission-denied` on `userMemos/{uid}`**
   - `PersonalMemo` が `subscribeToUserMemo` で `userMemos/{uid}` を購読
   - 既存ルールは `resource.data.userId == request.auth.uid` だが、ドキュメント未作成時は resource が無いので評価不能 → permission-denied
   - **Fix**: doc ID 自体が uid なので `memoId == request.auth.uid` に切り替え。create/update では更に `request.resource.data.userId == auth.uid` も検証して他ユーザーへの書き込みは引き続き防ぐ。

2. **`failed-precondition: requires an index` on conversations**
   - dashboard scope の `useUnifiedConversations` が `users/{uid}/conversations where projectId == null orderBy updatedAt desc` を発行
   - 必要な複合インデックスが `firestore.indexes.json` に未定義
   - **Fix**: `conversations` 用の `projectId` + `updatedAt` インデックスを追加

### デプロイ手順（マージ後・手動）
```bash
firebase deploy --only firestore:rules,firestore:indexes
```
（Vercel デプロイでは Firestore rules / indexes は反映されないので別途 CLI 必要）

### Background
本日 #69 でデモログインを導入。デモユーザー（新規作成）でダッシュボードを開くと上記2エラーで permission-denied が出ていたが、原因はデモ機能ではなく Firestore rules の既存バグだった（Google ログインユーザーは長く使ってる人ばかりなので顕在化していなかった）。

## Test plan
- [x] `npm run lint`
- [ ] CI 全緑
- [ ] マージ後 `firebase deploy --only firestore:rules,firestore:indexes`
- [ ] 本番でデモログイン → ダッシュボードで permission-denied / failed-precondition が出ない
- [ ] ダッシュボードに3プロジェクトが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)