### PR TITLE
fix(ai): 連続するツール実行確認で2回目のダイアログが空になり実行できないバグを修正

### DIFF
--- a/docs/E2E_STRATEGY.md
+++ b/docs/E2E_STRATEGY.md
@@ -48,6 +48,23 @@ Use it for flows like:
 - task editing
 - calendar and gantt behavior
 
+## Local Full-Suite Caveats (2026-07-07 時点)
+
+素の `npm run test:e2e`（実 Firebase 環境）でフルスイートを回すときの既知の注意点:
+
+- **テストユーザーは Firestore 権限がない**: `test-login` のユーザーではプロジェクトの購読・作成が
+  `Missing or insufficient permissions` で失敗する。`createProject` ヘルパーに依存するテスト
+  （calendar.spec など）はこの環境では失敗し、project.spec は自動スキップする。
+  プロジェクトデータが必要なテストは **デモログイン（`data-testid="demo-login"`、シード済み
+  プロジェクトあり）** を使うこと（例: `e2e/ai-tool-confirm.spec.ts`）。
+- **スモーク3本（auth-smoke / authenticated-smoke / demo-login）は素の実行では失敗する設計**:
+  これらは `npm run test:e2e:smoke`（`scripts/run-playwright-smoke.mjs`）が注入する
+  ダミー Firebase 設定・環境フラグが前提。フルスイートでの失敗は想定内で、判定はスモークランナー側で行う。
+- **開発ビルドの React Query Devtools ボタンが右下の相棒AIトグルに重なる**: クリックが
+  intercept されるので、テスト側で `.tsqd-parent-container { display: none !important; }` を注入する。
+- **AI チャットのテスト**: `/api/ai/chat`（SSE）と `/api/ai/settings` を `page.route` でモックし、
+  `ai-settings-storage` の localStorage を `addInitScript` で注入すればプロバイダ設定済み状態を再現できる。
+
 ## Expansion Plan
 
 Near-term target:

--- a/e2e/ai-tool-confirm.spec.ts
+++ b/e2e/ai-tool-confirm.spec.ts
@@ -1,0 +1,137 @@
+import { test, expect, Page } from '@playwright/test';
+
+/**
+ * 相棒AIのツール実行確認ダイアログのE2Eテスト
+ *
+ * 回帰テスト: ツール連鎖の途中でAIが2回目の確認を要求したとき、
+ * 1回目の確認処理の後始末（setPendingTools(null)）が新しい確認内容を
+ * 上書きしてしまい、ダイアログが空表示になり「実行する」が無反応になるバグ。
+ */
+
+// SSE レスポンスを組み立てる
+function sse(events: Array<Record<string, unknown>>): string {
+  return (
+    events.map((e) => `data: ${JSON.stringify(e)}`).join('\n\n') +
+    '\n\ndata: [DONE]\n\n'
+  );
+}
+
+// AIチャットAPIをモック:
+// マーカーを含むユーザー発話に対し、確認必須ツール(delete_task)を2ラウンド連続で返す
+async function mockAIChat(page: Page, marker: string) {
+  await page.route('**/api/ai/chat', async (route) => {
+    const body = route.request().postDataJSON() as {
+      messages?: Array<{ role: string; content: string }>;
+    };
+    const messages = body?.messages ?? [];
+    const toolRounds = messages.filter((m) => m.role === 'tool').length;
+    const lastUser = [...messages].reverse().find((m) => m.role === 'user');
+
+    let payload: string;
+    if (!lastUser?.content?.includes(marker)) {
+      // 自動挨拶などテスト対象外の呼び出しはテキストのみ返す
+      payload = sse([{ type: 'text', content: 'こんにちは！' }]);
+    } else if (toolRounds === 0) {
+      payload = sse([
+        { type: 'text', content: '1件目のタスクを削除します。' },
+        {
+          type: 'tool_calls',
+          toolCalls: [
+            { id: 'call-1', name: 'delete_task', arguments: { taskId: 'e2e-task-1' } },
+          ],
+        },
+      ]);
+    } else if (toolRounds === 1) {
+      // ツール連鎖の途中で再度確認が必要な操作を要求（バグの再現条件）
+      payload = sse([
+        { type: 'text', content: '続けて2件目のタスクを削除します。' },
+        {
+          type: 'tool_calls',
+          toolCalls: [
+            { id: 'call-2', name: 'delete_task', arguments: { taskId: 'e2e-task-2' } },
+          ],
+        },
+      ]);
+    } else {
+      payload = sse([{ type: 'text', content: 'すべての操作が完了しました。' }]);
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'text/event-stream',
+      body: payload,
+    });
+  });
+}
+
+test.describe('相棒AI ツール実行確認ダイアログ', () => {
+  test('連続する確認ダイアログで2回目も内容が表示され実行できる', async ({ page }) => {
+    const marker = 'E2E確認テスト';
+
+    // テストユーザーはFirestore権限がないため、シード済みプロジェクトを持つ
+    // デモユーザーでログインする（AIパネルはプロジェクトが1つ以上ないと無効）
+    await page.goto('/login');
+    await page.getByTestId('demo-login').click();
+    await page.waitForURL('/', { timeout: 60000 });
+
+    // AIプロバイダ設定済みの状態を再現（キー自体はモックするので不要）
+    await page.addInitScript(() => {
+      window.localStorage.setItem(
+        'ai-settings-storage',
+        JSON.stringify({
+          state: { provider: 'openai', openaiKeyConfigured: true },
+          version: 0,
+        })
+      );
+    });
+
+    // AI関連APIをモック
+    await page.route('**/api/ai/settings', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ allowedProjectIds: null }),
+      })
+    );
+    await mockAIChat(page, marker);
+
+    await page.goto('/');
+
+    // 開発ビルドの React Query Devtools ボタンが右下のAIトグルに重なるため非表示にする
+    await page.addStyleTag({
+      content: '.tsqd-parent-container { display: none !important; }',
+    });
+
+    // AIパネルを開いてメッセージ送信
+    await page.click('[data-testid="companion-ai-toggle"]');
+    const input = page.locator('textarea[placeholder*="何でも聞いてください"]');
+    await expect(input).toBeVisible({ timeout: 10000 });
+    await expect(input).toBeEnabled({ timeout: 15000 });
+    await input.fill(`${marker}: 完了済みタスクを2件削除して`);
+    await input.press('Enter');
+
+    // --- 1回目の確認ダイアログ ---
+    const executeButton = page.locator('[data-testid="tool-confirm-execute"]');
+    await expect(executeButton).toBeVisible({ timeout: 15000 });
+    await expect(
+      page.locator('[data-testid="tool-confirm-item"]').first()
+    ).toBeVisible();
+    await executeButton.click();
+
+    // --- 2回目の確認ダイアログ（回帰の本丸） ---
+    // 旧コードでは pendingTools が null に上書きされ、
+    // 内容が空になり「実行する」を押しても何も起きなかった
+    await expect(executeButton).toBeVisible({ timeout: 15000 });
+    await expect(
+      page.locator('[data-testid="tool-confirm-item"]').first()
+    ).toBeVisible({ timeout: 5000 });
+    await expect(executeButton).toBeEnabled();
+    await executeButton.click();
+
+    // 実行ボタンのクリックが機能し、ダイアログが閉じて完了メッセージが表示される
+    await expect(executeButton).not.toBeVisible({ timeout: 15000 });
+    await expect(page.locator('text=すべての操作が完了しました。')).toBeVisible({
+      timeout: 15000,
+    });
+  });
+});

--- a/src/components/ai/CompanionAI.tsx
+++ b/src/components/ai/CompanionAI.tsx
@@ -485,9 +485,12 @@ export function CompanionAI({ projectId }: CompanionAIProps) {
   const handleToolConfirm = useCallback(async () => {
     if (!pendingTools) return;
 
+    const tools = pendingTools;
     setShowToolConfirm(false);
-    await confirmToolExecution(pendingTools);
+    // 実行中にAIが次の確認を要求すると pendingTools が再セットされるため、
+    // await 後にクリアすると新しい確認内容を上書きしてしまう。必ず実行前にクリアする。
     setPendingTools(null);
+    await confirmToolExecution(tools);
   }, [pendingTools, confirmToolExecution]);
 
   // Handle tool cancellation
@@ -597,6 +600,7 @@ export function CompanionAI({ projectId }: CompanionAIProps) {
     <>
       {/* Floating Button */}
       <button
+        data-testid="companion-ai-toggle"
         onClick={() => setIsOpen(!isOpen)}
         className={cn(
           'fixed bottom-6 right-6 z-50 flex h-14 w-14 items-center justify-center rounded-full shadow-lg transition-all hover:scale-105',

--- a/src/components/ai/ToolConfirmDialog.tsx
+++ b/src/components/ai/ToolConfirmDialog.tsx
@@ -95,6 +95,7 @@ export function ToolConfirmDialog({
             {descriptions.map((desc, index) => (
               <li
                 key={index}
+                data-testid="tool-confirm-item"
                 className="flex items-start gap-2 rounded-md border bg-muted/30 p-3 text-sm"
               >
                 <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
@@ -109,12 +110,14 @@ export function ToolConfirmDialog({
             variant="outline"
             onClick={onCancel}
             disabled={isExecuting}
+            data-testid="tool-confirm-cancel"
           >
             キャンセル
           </Button>
           <Button
             onClick={onConfirm}
             disabled={isExecuting}
+            data-testid="tool-confirm-execute"
           >
             {isExecuting ? (
               <>

--- a/src/hooks/useUnifiedConversation.ts
+++ b/src/hooks/useUnifiedConversation.ts
@@ -416,6 +416,9 @@ export function useUnifiedConversation({
     if (!currentConversationId) return;
 
     setIsLoading(true);
+    // finally でクリアすると、processToolCalls の連鎖中に発生した次の確認要求
+    // （pendingToolCallsRef への再セット）を上書きしてしまうため、実行開始時にクリアする
+    pendingToolCallsRef.current = null;
     try {
       await processToolCalls(toolCalls, messages, currentConversationId);
     } catch (err) {
@@ -423,7 +426,6 @@ export function useUnifiedConversation({
       setError(errorMessage);
     } finally {
       setIsLoading(false);
-      pendingToolCallsRef.current = null;
     }
   }, [currentConversationId, messages, processToolCalls]);
 


### PR DESCRIPTION
## 概要

サポートAI（相棒AI）に一括操作を指示した際、2回目の「操作を実行しますか？」ダイアログが空表示になり、「実行する」を押しても無反応になる不具合の修正。

## 原因

「実行する」クリック後の後始末 `setPendingTools(null)` が `await confirmToolExecution()` の**後**に実行されるため、ツール連鎖の途中でAIが次の確認を要求して新しい `pendingTools` がセットされた直後に null で上書きされていた。結果、ダイアログは開いたまま内容が空になり、実行ボタンは冒頭ガード `if (!pendingTools) return` で無反応になる。

## 変更内容

- `CompanionAI.tsx`: `pendingTools` のクリアを `await` の前に移動
- `useUnifiedConversation.ts`: `pendingToolCallsRef` のクリアを `finally` から実行開始時に移動（同種の上書き防止）
- 回帰E2Eテスト `e2e/ai-tool-confirm.spec.ts` を追加（`/api/ai/chat` をSSEモックし、確認必須ツールを2ラウンド連続で発生させて検証。**旧コードで失敗することを確認済み**）
- テスト用 `data-testid` を3箇所追加
- `docs/E2E_STRATEGY.md` にローカルフルスイートの既知の注意点を追記

## テスト

- 新規E2E: パス（旧コードでは失敗することも確認）
- `npm run lint` / ユニットテスト81件 / `npm run test:e2e:smoke`: すべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)