### PR TITLE
feat(projects): アーカイブ済みプロジェクトの表示と復元機能を追加

### DIFF
--- a/e2e/project.spec.ts
+++ b/e2e/project.spec.ts
@@ -73,6 +73,58 @@ test.describe('Project Management', () => {
     await expect(page).toHaveURL(/\/projects\/.*\/board/, { timeout: 30000 });
   });
 
+  test('should archive and restore a project', async ({ page }) => {
+    await page.goto('/projects');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByRole('button', { name: '新規プロジェクト' })).toBeVisible({ timeout: 60000 });
+    await page.waitForTimeout(3000);
+
+    const projectCards = page.locator('main [data-testid="project-card"]');
+    const count = await projectCards.count();
+
+    if (count === 0) {
+      console.log('No accessible projects found - skipping archive test');
+      test.skip();
+      return;
+    }
+
+    // Remember the name of the project we archive
+    const firstCard = projectCards.first();
+    const projectName = (await firstCard.locator('h3').innerText()).trim();
+
+    // Accept the confirm() dialog for archiving
+    page.once('dialog', (dialog) => dialog.accept());
+
+    // Open the card's dropdown menu and click アーカイブ
+    await firstCard.hover();
+    await firstCard.getByRole('button').click();
+    await page.getByRole('menuitem', { name: 'アーカイブ' }).click();
+
+    // Archived section toggle should appear
+    const toggle = page.getByTestId('toggle-archived-projects');
+    await expect(toggle).toBeVisible({ timeout: 30000 });
+
+    // Expand archived section and verify the project is there
+    await toggle.click();
+    const archivedSection = page.getByTestId('archived-projects-section');
+    await expect(archivedSection.getByText(projectName)).toBeVisible({ timeout: 30000 });
+
+    // Restore the project
+    const archivedCard = archivedSection
+      .locator('[data-testid="project-card"]')
+      .filter({ hasText: projectName })
+      .first();
+    await archivedCard.hover();
+    await archivedCard.getByRole('button').click();
+    await page.getByRole('menuitem', { name: '復元' }).click();
+
+    // The project should be back in the active list
+    await expect(
+      page.locator('main [data-testid="project-card"]').filter({ hasText: projectName }).first()
+    ).toBeVisible({ timeout: 30000 });
+  });
+
   test('should navigate to project settings', async ({ page }) => {
     await page.goto('/projects');
     await page.waitForLoadState('networkidle');

--- a/src/app/(dashboard)/projects/page.tsx
+++ b/src/app/(dashboard)/projects/page.tsx
@@ -1,20 +1,27 @@
 'use client';
 
-import { Plus, FolderKanban } from 'lucide-react';
+import { useState } from 'react';
+import { Plus, FolderKanban, Archive, ChevronDown, ChevronRight } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { ProjectCard } from '@/components/project/ProjectCard';
-import { useProjects } from '@/hooks/useProjects';
+import { useProjects, useArchivedProjects } from '@/hooks/useProjects';
 import { useUIStore } from '@/stores/uiStore';
 import { Loader2 } from 'lucide-react';
 
 export default function ProjectsPage() {
   const { projects, isLoading, archive, remove } = useProjects();
+  const { archivedProjects, restore } = useArchivedProjects();
   const { openProjectModal } = useUIStore();
+  const [showArchived, setShowArchived] = useState(false);
 
   const handleArchive = async (projectId: string) => {
     if (confirm('このプロジェクトをアーカイブしますか？')) {
       await archive(projectId, true);
     }
+  };
+
+  const handleRestore = async (projectId: string) => {
+    await restore(projectId);
   };
 
   const handleDelete = async (projectId: string) => {
@@ -72,6 +79,41 @@ export default function ProjectsPage() {
               onDelete={handleDelete}
             />
           ))}
+        </div>
+      )}
+
+      {archivedProjects.length > 0 && (
+        <div className="space-y-4">
+          <button
+            type="button"
+            onClick={() => setShowArchived((prev) => !prev)}
+            className="flex items-center gap-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+            data-testid="toggle-archived-projects"
+          >
+            {showArchived ? (
+              <ChevronDown className="h-4 w-4" />
+            ) : (
+              <ChevronRight className="h-4 w-4" />
+            )}
+            <Archive className="h-4 w-4" />
+            アーカイブ済みプロジェクト（{archivedProjects.length}）
+          </button>
+
+          {showArchived && (
+            <div
+              className="grid gap-4 opacity-75 sm:grid-cols-2 lg:grid-cols-3"
+              data-testid="archived-projects-section"
+            >
+              {archivedProjects.map((project) => (
+                <ProjectCard
+                  key={project.id}
+                  project={project}
+                  onRestore={handleRestore}
+                  onDelete={handleDelete}
+                />
+              ))}
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/components/project/ProjectCard.tsx
+++ b/src/components/project/ProjectCard.tsx
@@ -2,7 +2,7 @@
 
 import Image from 'next/image';
 import Link from 'next/link';
-import { MoreHorizontal, Users, Archive, Trash2, Settings } from 'lucide-react';
+import { MoreHorizontal, Users, Archive, ArchiveRestore, Trash2, Settings } from 'lucide-react';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import {
@@ -20,6 +20,7 @@ interface ProjectCardProps {
   project: Project;
   taskCount?: number;
   onArchive?: (projectId: string) => void;
+  onRestore?: (projectId: string) => void;
   onDelete?: (projectId: string) => void;
 }
 
@@ -27,6 +28,7 @@ export function ProjectCard({
   project,
   taskCount = 0,
   onArchive,
+  onRestore,
   onDelete,
 }: ProjectCardProps) {
   return (
@@ -88,10 +90,17 @@ export function ProjectCard({
               </Link>
             </DropdownMenuItem>
             <DropdownMenuSeparator />
-            <DropdownMenuItem onClick={() => onArchive?.(project.id)}>
-              <Archive className="mr-2 h-4 w-4" />
-              アーカイブ
-            </DropdownMenuItem>
+            {project.isArchived ? (
+              <DropdownMenuItem onClick={() => onRestore?.(project.id)}>
+                <ArchiveRestore className="mr-2 h-4 w-4" />
+                復元
+              </DropdownMenuItem>
+            ) : (
+              <DropdownMenuItem onClick={() => onArchive?.(project.id)}>
+                <Archive className="mr-2 h-4 w-4" />
+                アーカイブ
+              </DropdownMenuItem>
+            )}
             <DropdownMenuItem
               onClick={() => onDelete?.(project.id)}
               className="text-red-600"

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -9,6 +9,7 @@ import {
   deleteProject,
   archiveProject,
   subscribeToUserProjects,
+  subscribeToArchivedUserProjects,
   reorderProjects,
   getProjectMembers,
   addProjectMember,
@@ -147,6 +148,70 @@ export function useProjects() {
     remove,
     archive,
     reorder,
+  };
+}
+
+export function useArchivedProjects() {
+  const { firebaseUser } = useAuthStore();
+  const [archivedProjects, setArchivedProjects] = useState<Project[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  // Subscribe to user's archived projects
+  useEffect(() => {
+    if (isE2EMockAuthEnabled()) {
+      Promise.resolve().then(() => {
+        setArchivedProjects([]);
+        setIsLoading(false);
+        setError(null);
+      });
+      return;
+    }
+
+    if (!firebaseUser) {
+      Promise.resolve().then(() => {
+        setArchivedProjects([]);
+        setIsLoading(false);
+      });
+      return;
+    }
+
+    Promise.resolve().then(() => {
+      setIsLoading(true);
+      setError(null);
+    });
+    const unsubscribe = subscribeToArchivedUserProjects(
+      firebaseUser.uid,
+      (projects) => {
+        setArchivedProjects(projects);
+        setIsLoading(false);
+        setError(null);
+      },
+      (err) => {
+        console.error('[useArchivedProjects] Error:', err);
+        setError(err);
+        setIsLoading(false);
+      }
+    );
+
+    return () => unsubscribe();
+  }, [firebaseUser]);
+
+  // Restore (unarchive) project
+  const restore = useCallback(async (projectId: string) => {
+    try {
+      await archiveProject(projectId, false);
+    } catch (err) {
+      setError(err as Error);
+      throw err;
+    }
+  }, []);
+
+  return {
+    archivedProjects,
+    isLoading,
+    error,
+    restore,
   };
 }
 

--- a/src/lib/firebase/firestore.ts
+++ b/src/lib/firebase/firestore.ts
@@ -245,6 +245,35 @@ export function subscribeToUserProjects(
   );
 }
 
+export function subscribeToArchivedUserProjects(
+  userId: string,
+  callback: (projects: Project[]) => void,
+  onError?: (error: Error) => void
+): () => void {
+  const db = getFirebaseDb();
+  const q = query(
+    collection(db, 'projects'),
+    where('memberIds', 'array-contains', userId),
+    where('isArchived', '==', true)
+  );
+
+  return onSnapshot(
+    q,
+    (snapshot) => {
+      const projects = snapshot.docs
+        .map((doc) => convertDoc<Project>(doc.data(), doc.id))
+        .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+      callback(projects);
+    },
+    (error) => {
+      console.error('[Firestore] subscribeToArchivedUserProjects error:', error);
+      if (onError) {
+        onError(error);
+      }
+    }
+  );
+}
+
 export async function updateProjectOrder(projectId: string, order: number): Promise<void> {
   const db = getFirebaseDb();
   await updateDoc(doc(db, 'projects', projectId), {


### PR DESCRIPTION
## 概要
プロジェクトのアーカイブ機能を完成させる。アーカイブ自体（カードメニューの「アーカイブ」）は既に存在したが、アーカイブ済みプロジェクトを閲覧・復元するUIがなく、アーカイブすると実質戻せない状態だった。

## 変更内容
- `subscribeToArchivedUserProjects`: `isArchived == true` のプロジェクトをリアルタイム購読（既存の複合インデックスでカバー済み、インデックス追加不要）
- `useArchivedProjects` フック: アーカイブ済み一覧の購読と `restore`（アーカイブ解除）
- プロジェクト一覧ページ: 下部に「アーカイブ済みプロジェクト（N）」の開閉セクションを追加
- `ProjectCard`: アーカイブ済みの場合はメニューに「アーカイブ」の代わりに「復元」を表示
- E2E: 既存プロジェクトをアーカイブ→復元する往復テストを追加（プロジェクトが取得できない環境では skip）

## テスト
- `npm run lint` パス
- `npm run test:e2e:smoke` パス（3件）
- `npx playwright test e2e/project.spec.ts` 2 passed / 4 skipped / 0 failed（skip はローカル環境の Firestore 権限による既存同様の挙動）
- `tsc --noEmit` のエラーは既存テストファイル由来（main でも同一エラーを確認済み、本PRとは無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)