### PR TITLE
fix(board): 上の追加ボタンからのタスク作成をリスト先頭に挿入

### DIFF
--- a/src/components/board/BoardList.test.tsx
+++ b/src/components/board/BoardList.test.tsx
@@ -97,7 +97,35 @@ describe('BoardList', () => {
     });
     fireEvent.click(screen.getByRole('button', { name: '追加' }));
 
-    expect(onAddTask).toHaveBeenCalledWith('末尾で追加するタスク');
+    expect(onAddTask).toHaveBeenCalledWith('末尾で追加するタスク', 'bottom');
     expect(screen.getAllByRole('button', { name: 'タスクを追加' })).toHaveLength(2);
+  });
+
+  it('reports top position when launched from the top add button', () => {
+    const onAddTask = vi.fn();
+
+    render(
+      <BoardList
+        projectId="project-1"
+        list={list}
+        tasks={[task]}
+        allTasks={[task]}
+        labels={[]}
+        tags={[]}
+        onAddTask={onAddTask}
+        onEditList={vi.fn()}
+        onDeleteList={vi.fn()}
+        onTaskClick={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'タスクを追加' })[0]);
+
+    fireEvent.change(screen.getByPlaceholderText('タスク名を入力...'), {
+      target: { value: '先頭で追加するタスク' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '追加' }));
+
+    expect(onAddTask).toHaveBeenCalledWith('先頭で追加するタスク', 'top');
   });
 });

--- a/src/components/board/BoardList.tsx
+++ b/src/components/board/BoardList.tsx
@@ -40,7 +40,7 @@ interface BoardListProps {
   allTasks: Task[]; // All tasks in project for dependency lookup
   labels: Label[];
   tags: Tag[];
-  onAddTask: (title: string) => void;
+  onAddTask: (title: string, position: 'top' | 'bottom') => void;
   onEditList: (data: { name?: string; color?: string; autoCompleteOnEnter?: boolean; autoUncompleteOnExit?: boolean }) => void;
   onDeleteList: () => void;
   onTaskClick: (taskId: string) => void;
@@ -93,8 +93,8 @@ export function BoardList({
   };
 
   const handleAddTask = () => {
-    if (newTaskTitle.trim()) {
-      onAddTask(newTaskTitle.trim());
+    if (newTaskTitle.trim() && taskComposerPosition) {
+      onAddTask(newTaskTitle.trim(), taskComposerPosition);
       closeTaskComposer();
     }
   };

--- a/src/components/board/BoardView.tsx
+++ b/src/components/board/BoardView.tsx
@@ -361,9 +361,9 @@ export function BoardView({ projectId, onTaskClick, filters }: BoardViewProps) {
     }
   };
 
-  const handleAddTask = (listId: string) => (title: string) => {
+  const handleAddTask = (listId: string) => (title: string, position: 'top' | 'bottom') => {
     if (firebaseUser) {
-      addTask(listId, title, firebaseUser.uid);
+      addTask(listId, title, firebaseUser.uid, position);
     }
   };
 

--- a/src/hooks/useBoard.ts
+++ b/src/hooks/useBoard.ts
@@ -193,10 +193,12 @@ export function useBoard(projectId: string | null) {
 
   // Create task
   const addTask = useCallback(
-    async (listId: string, title: string, createdBy: string) => {
+    async (listId: string, title: string, createdBy: string, position: 'top' | 'bottom' = 'bottom') => {
       if (!projectId) return;
       const tasksInList = state.tasks.filter((t) => t.listId === listId);
-      const maxOrder = Math.max(...tasksInList.map((t) => t.order), -1);
+      const orders = tasksInList.map((t) => t.order);
+      const order =
+        position === 'top' ? Math.min(...orders, 1) - 1 : Math.max(...orders, -1) + 1;
 
       // Check if the target list has auto-complete enabled
       const targetList = state.lists.find((l) => l.id === listId);
@@ -206,7 +208,7 @@ export function useBoard(projectId: string | null) {
         listId,
         title,
         description: '',
-        order: maxOrder + 1,
+        order,
         assigneeIds: [],
         labelIds: [],
         tagIds: [],


### PR DESCRIPTION
## 概要
リストの上下に「タスクを追加」ボタンがあるが、どちらから作成してもタスクが一番下に追加されていた。上のボタンから作成した場合は一番上に、下のボタンからは従来どおり一番下に追加されるように修正。

## 変更内容
- `BoardList`: コンポーザの位置（top/bottom）を `onAddTask` の第2引数として通知
- `BoardView`: position を `addTask` へ伝搬
- `useBoard.addTask`: position が top の場合は既存タスクの最小 order より小さい値（bottom は従来どおり最大 order + 1）で作成

## テスト
- `BoardList.test.tsx` に上ボタン経由で `top` が渡ることの検証を追加（vitest 2件パス）
- `tsc --noEmit`: 変更ファイルにエラーなし（既存9件は main 由来）
- Playwright: board.spec はテスト環境にプロジェクトが無くスキップ（既存の制約）。auth-smoke の失敗1件は .env.local のテストログイン設定に起因する環境要因で本変更とは無関係

🤖 Generated with [Claude Code](https://claude.com/claude-code)