### PR TITLE
fix(ui): カレンダーを日本語ロケール表示に変更

### DIFF
--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -11,6 +11,7 @@ import {
   getDefaultClassNames,
   type DayButton,
 } from "react-day-picker"
+import { ja } from "react-day-picker/locale"
 
 import { cn } from "@/lib/utils"
 import { Button, buttonVariants } from "@/components/ui/button"
@@ -31,6 +32,7 @@ function Calendar({
 
   return (
     <DayPicker
+      locale={ja}
       showOutsideDays={showOutsideDays}
       className={cn(
         "bg-background group/calendar p-3 [--cell-size:--spacing(8)] [[data-slot=card-content]_&]:bg-transparent [[data-slot=popover-content]_&]:bg-transparent",
@@ -41,7 +43,7 @@ function Calendar({
       captionLayout={captionLayout}
       formatters={{
         formatMonthDropdown: (date) =>
-          date.toLocaleString("default", { month: "short" }),
+          date.toLocaleString("ja-JP", { month: "short" }),
         ...formatters,
       }}
       classNames={{


### PR DESCRIPTION
## 概要
タスクの開始日/期限日ピッカーのカレンダー（react-day-picker）が英語表示（July 2026 / Su Mo Tu...）だったため、日本語表示に変更。

## 変更内容
- `src/components/ui/calendar.tsx` の `DayPicker` にデフォルトで `locale={ja}` を設定
- 月ドロップダウンのフォーマッターを `ja-JP` ロケールに変更

呼び出し側にロケール上書きはないため、アプリ内の全カレンダーに適用されます。

## テスト
- `npx playwright test`: 10 passed / 15 skipped（calendar.spec.ts 含め全パス）
- 型チェック: calendar.tsx にエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)