### PR TITLE
fix: AI確認ダイアログに削除対象のタスク名を表示

### DIFF
--- a/e2e/ai-tool-confirm.spec.ts
+++ b/e2e/ai-tool-confirm.spec.ts
@@ -37,7 +37,11 @@ async function mockAIChat(page: Page, marker: string) {
         {
           type: 'tool_calls',
           toolCalls: [
-            { id: 'call-1', name: 'delete_task', arguments: { taskId: 'e2e-task-1' } },
+            {
+              id: 'call-1',
+              name: 'delete_task',
+              arguments: { taskId: 'e2e-task-1', taskTitle: 'E2E削除対象タスク1' },
+            },
           ],
         },
       ]);
@@ -48,7 +52,11 @@ async function mockAIChat(page: Page, marker: string) {
         {
           type: 'tool_calls',
           toolCalls: [
-            { id: 'call-2', name: 'delete_task', arguments: { taskId: 'e2e-task-2' } },
+            {
+              id: 'call-2',
+              name: 'delete_task',
+              arguments: { taskId: 'e2e-task-2', taskTitle: 'E2E削除対象タスク2' },
+            },
           ],
         },
       ]);
@@ -113,9 +121,10 @@ test.describe('相棒AI ツール実行確認ダイアログ', () => {
     // --- 1回目の確認ダイアログ ---
     const executeButton = page.locator('[data-testid="tool-confirm-execute"]');
     await expect(executeButton).toBeVisible({ timeout: 15000 });
+    // 削除対象のタスク名が表示される（「タスクを削除」だけの匿名表示にならない）
     await expect(
       page.locator('[data-testid="tool-confirm-item"]').first()
-    ).toBeVisible();
+    ).toContainText('E2E削除対象タスク1');
     await executeButton.click();
 
     // --- 2回目の確認ダイアログ（回帰の本丸） ---
@@ -124,7 +133,7 @@ test.describe('相棒AI ツール実行確認ダイアログ', () => {
     await expect(executeButton).toBeVisible({ timeout: 15000 });
     await expect(
       page.locator('[data-testid="tool-confirm-item"]').first()
-    ).toBeVisible({ timeout: 5000 });
+    ).toContainText('E2E削除対象タスク2', { timeout: 5000 });
     await expect(executeButton).toBeEnabled();
     await executeButton.click();
 

--- a/src/lib/ai/toolExecutor.ts
+++ b/src/lib/ai/toolExecutor.ts
@@ -84,6 +84,14 @@ export function requiresConfirmation(toolCalls: ToolCall[]): boolean {
   return toolCalls.some((call) => TOOLS_REQUIRING_CONFIRMATION.includes(call.name));
 }
 
+// taskTitle が引数に含まれていれば「タイトル」、なければ ID 末尾で対象を識別できるようにする
+function taskLabel(args: unknown): string {
+  const { taskTitle, taskId } = (args ?? {}) as { taskTitle?: string; taskId?: string };
+  if (taskTitle) return `「${taskTitle}」`;
+  if (taskId) return `（ID: ${taskId}）`;
+  return '';
+}
+
 /**
  * Get human-readable description of tool calls for confirmation dialog
  */
@@ -118,24 +126,30 @@ export function getToolCallsDescription(toolCalls: ToolCall[]): string[] {
         if (args.priority) updates.push(`優先度→${args.priority}`);
         if (args.dueDate) updates.push(`期限→${args.dueDate}`);
         if (args.isCompleted !== undefined) updates.push(args.isCompleted ? '完了にする' : '未完了に戻す');
-        return `タスクを更新: ${updates.join(', ')}`;
+        return `タスク${taskLabel(call.arguments)}を更新: ${updates.join(', ')}`;
       }
       case 'delete_task': {
-        return `タスクを削除`;
+        return `タスク${taskLabel(call.arguments)}を削除`;
       }
       case 'complete_task': {
         const args = call.arguments as { taskId: string; isCompleted: boolean };
-        return args.isCompleted ? 'タスクを完了にする' : 'タスクを未完了に戻す';
+        const label = taskLabel(call.arguments);
+        return args.isCompleted ? `タスク${label}を完了にする` : `タスク${label}を未完了に戻す`;
       }
       case 'move_task': {
-        return `タスクを別のリストに移動`;
+        const args = call.arguments as { listName?: string };
+        const label = taskLabel(call.arguments);
+        return args.listName
+          ? `タスク${label}を「${args.listName}」に移動`
+          : `タスク${label}を別のリストに移動`;
       }
       case 'assign_task': {
         const args = call.arguments as { taskId: string; assigneeIds: string[] };
+        const label = taskLabel(call.arguments);
         if (args.assigneeIds.length === 0) {
-          return `タスクの担当者をクリア`;
+          return `タスク${label}の担当者をクリア`;
         }
-        return `タスクに${args.assigneeIds.length}人の担当者を設定`;
+        return `タスク${label}に${args.assigneeIds.length}人の担当者を設定`;
       }
       // Read-only tools (no confirmation needed, but include for completeness)
       case 'get_tasks':

--- a/src/lib/ai/tools/deleteTask.ts
+++ b/src/lib/ai/tools/deleteTask.ts
@@ -4,6 +4,7 @@ import { AITool, ToolHandler } from './types';
 // Delete (archive) task argument types
 export interface DeleteTaskArgs {
   taskId: string;
+  taskTitle?: string;
 }
 
 export interface DeleteTaskResult {
@@ -28,8 +29,12 @@ export const deleteTaskToolDefinition: AITool = {
         type: 'string',
         description: '削除するタスクのID（必須）',
       },
+      taskTitle: {
+        type: 'string',
+        description: '削除するタスクのタイトル（確認ダイアログの表示に使うため必ず指定）',
+      },
     },
-    required: ['taskId'],
+    required: ['taskId', 'taskTitle'],
   },
 };
 

--- a/src/lib/ai/tools/taskTools.ts
+++ b/src/lib/ai/tools/taskTools.ts
@@ -16,6 +16,7 @@ import { AITool, ToolHandler } from './types';
 export interface CompleteTaskArgs {
   projectId?: string;
   taskId: string;
+  taskTitle?: string;
   isCompleted: boolean;
 }
 
@@ -40,6 +41,10 @@ export const completeTaskToolDefinition: AITool = {
       taskId: {
         type: 'string',
         description: 'タスクのID（必須）',
+      },
+      taskTitle: {
+        type: 'string',
+        description: '対象タスクのタイトル（確認ダイアログの表示に使うため必ず指定）',
       },
       isCompleted: {
         type: 'boolean',
@@ -85,7 +90,9 @@ export const completeTaskHandler: ToolHandler<CompleteTaskArgs, CompleteTaskResu
 
 export interface MoveTaskArgs {
   taskId: string;
+  taskTitle?: string;
   listId: string;
+  listName?: string;
 }
 
 export interface MoveTaskResult {
@@ -107,12 +114,20 @@ export const moveTaskToolDefinition: AITool = {
         type: 'string',
         description: 'タスクのID（必須）',
       },
+      taskTitle: {
+        type: 'string',
+        description: '対象タスクのタイトル（確認ダイアログの表示に使うため必ず指定）',
+      },
       listId: {
         type: 'string',
         description: '移動先のリストID（必須）',
       },
+      listName: {
+        type: 'string',
+        description: '移動先のリスト名（確認ダイアログの表示に使うため必ず指定）',
+      },
     },
-    required: ['taskId', 'listId'],
+    required: ['taskId', 'taskTitle', 'listId', 'listName'],
   },
 };
 
@@ -156,6 +171,7 @@ export const moveTaskHandler: ToolHandler<MoveTaskArgs, MoveTaskResult> = async 
 
 export interface AssignTaskArgs {
   taskId: string;
+  taskTitle?: string;
   assigneeIds: string[];
 }
 
@@ -176,6 +192,10 @@ export const assignTaskToolDefinition: AITool = {
       taskId: {
         type: 'string',
         description: 'タスクのID（必須）',
+      },
+      taskTitle: {
+        type: 'string',
+        description: '対象タスクのタイトル（確認ダイアログの表示に使うため必ず指定）',
       },
       assigneeIds: {
         type: 'array',

--- a/src/lib/ai/tools/updateTask.ts
+++ b/src/lib/ai/tools/updateTask.ts
@@ -7,6 +7,7 @@ import { recalculateDates } from '@/lib/utils/task';
 export interface UpdateTaskArgs {
   projectId?: string;
   taskId: string;
+  taskTitle?: string;
   title?: string;
   description?: string;
   priority?: 'high' | 'medium' | 'low';
@@ -42,6 +43,10 @@ export const updateTaskToolDefinition: AITool = {
       taskId: {
         type: 'string',
         description: '更新するタスクのID（必須）',
+      },
+      taskTitle: {
+        type: 'string',
+        description: '更新するタスクの現在のタイトル（確認ダイアログの表示に使うため必ず指定）',
       },
       title: {
         type: 'string',


### PR DESCRIPTION
## 問題
サポートAIの削除確認ダイアログで、複数タスク削除時に全項目が「タスクを削除」としか表示されず、どのタスクが削除されるのか判別できなかった。

## 原因
`getToolCallsDescription` が `delete_task` に固定文字列を返しており、ツール引数に taskId しかなくタスク名を持っていなかった。

## 修正
- `delete_task` / `update_task` / `complete_task` / `move_task` / `assign_task` のツール定義に表示用の `taskTitle`（move には `listName` も）を追加
- 確認ダイアログの説明文でタスク名を表示。無い場合は `（ID: xxx）` にフォールバック
- E2Eテストにタスク名表示のアサーションを追加

## テスト
- `npx playwright test`: 10 passed / 15 skipped（全パス）

🤖 Generated with [Claude Code](https://claude.com/claude-code)