### PR TITLE
feat(board): リストに「ここに入ったら開始日を設定」オプションを追加

### DIFF
--- a/e2e/board.spec.ts
+++ b/e2e/board.spec.ts
@@ -209,4 +209,48 @@ test.describe('Board/Kanban', () => {
     await expect(page.locator('text=チェックリストの新規作成')).toBeVisible();
     await expect(page.locator('text=優先度')).toBeVisible();
   });
+
+  test('should toggle auto-set-start-date option in list menu', async ({ page }) => {
+    const projectCards = page.locator('main a[href*="/board"] h3');
+    const count = await projectCards.count();
+
+    if (count === 0) {
+      test.skip();
+      return;
+    }
+
+    const listName = `開始日リスト_${Date.now()}`;
+
+    await projectCards.first().click();
+    await expect(page.locator('text=リストを追加')).toBeVisible({ timeout: 10000 });
+
+    // Create a fresh list
+    await page.click('text=リストを追加');
+    const listInput = page.locator('input[placeholder*="リスト名"]');
+    await listInput.fill(listName);
+    await listInput.locator('..').locator('button:has-text("追加")').click();
+
+    const list = page.locator(`[data-testid="board-list"]:has(h3:has-text("${listName}"))`);
+    await expect(list).toBeVisible({ timeout: 10000 });
+
+    // Open list dropdown menu and toggle the option
+    await list.locator('button:has(svg.lucide-more-horizontal), button:has(svg.lucide-ellipsis)').first().click();
+    const menuItem = page.getByRole('menuitem', { name: 'ここに入ったら開始日を設定' });
+    await expect(menuItem).toBeVisible({ timeout: 5000 });
+    await menuItem.click();
+
+    // Reopen the menu and verify the ON indicator
+    await list.locator('button:has(svg.lucide-more-horizontal), button:has(svg.lucide-ellipsis)').first().click();
+    await expect(
+      page.getByRole('menuitem', { name: /ここに入ったら開始日を設定/ }).locator('text=ON')
+    ).toBeVisible({ timeout: 5000 });
+    await page.keyboard.press('Escape');
+
+    // Create a task in the list — startDate should be set automatically
+    await list.locator('button:has-text("タスクを追加")').first().click();
+    const taskTitle = `開始日タスク_${Date.now()}`;
+    await list.locator('input[placeholder*="タスク"]').fill(taskTitle);
+    await list.locator('button:has-text("追加")').click();
+    await expect(list.locator(`text=${taskTitle}`)).toBeVisible({ timeout: 10000 });
+  });
 });

--- a/scripts/seed-demo.mjs
+++ b/scripts/seed-demo.mjs
@@ -233,6 +233,7 @@ async function seedProject(db, uid, spec, projectOrder) {
       order: i,
       autoCompleteOnEnter: listSpec.name === '完了' || listSpec.name === 'リリース済み',
       autoUncompleteOnExit: false,
+      autoSetStartDateOnEnter: false,
       createdAt: FieldValue.serverTimestamp(),
       updatedAt: FieldValue.serverTimestamp(),
     });

--- a/src/components/board/BoardList.test.tsx
+++ b/src/components/board/BoardList.test.tsx
@@ -35,6 +35,7 @@ const list: List = {
   order: 0,
   autoCompleteOnEnter: false,
   autoUncompleteOnExit: false,
+  autoSetStartDateOnEnter: false,
   createdAt: new Date('2026-01-01T00:00:00.000Z'),
   updatedAt: new Date('2026-01-01T00:00:00.000Z'),
 };

--- a/src/components/board/BoardList.tsx
+++ b/src/components/board/BoardList.tsx
@@ -8,7 +8,7 @@ import {
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { useDroppable } from '@dnd-kit/core';
-import { MoreHorizontal, Plus, Trash2, Palette, GripVertical, CheckCircle2, CircleOff } from 'lucide-react';
+import { MoreHorizontal, Plus, Trash2, Palette, GripVertical, CheckCircle2, CircleOff, CalendarPlus } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import {
@@ -41,7 +41,7 @@ interface BoardListProps {
   labels: Label[];
   tags: Tag[];
   onAddTask: (title: string, position: 'top' | 'bottom') => void;
-  onEditList: (data: { name?: string; color?: string; autoCompleteOnEnter?: boolean; autoUncompleteOnExit?: boolean }) => void;
+  onEditList: (data: { name?: string; color?: string; autoCompleteOnEnter?: boolean; autoUncompleteOnExit?: boolean; autoSetStartDateOnEnter?: boolean }) => void;
   onDeleteList: () => void;
   onTaskClick: (taskId: string) => void;
 }
@@ -220,6 +220,13 @@ export function BoardList({
               <CircleOff className={cn('mr-2 h-4 w-4', list.autoUncompleteOnExit && 'text-amber-600')} />
               ここから出たら完了を外す
               {list.autoUncompleteOnExit && <span className="ml-auto text-xs text-amber-600">ON</span>}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={() => onEditList({ autoSetStartDateOnEnter: !list.autoSetStartDateOnEnter })}
+            >
+              <CalendarPlus className={cn('mr-2 h-4 w-4', list.autoSetStartDateOnEnter && 'text-blue-600')} />
+              ここに入ったら開始日を設定
+              {list.autoSetStartDateOnEnter && <span className="ml-auto text-xs text-blue-600">ON</span>}
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem

--- a/src/hooks/useBoard.ts
+++ b/src/hooks/useBoard.ts
@@ -114,6 +114,7 @@ export function useBoard(projectId: string | null) {
         order: maxOrder + 1,
         autoCompleteOnEnter: false,
         autoUncompleteOnExit: false,
+        autoSetStartDateOnEnter: false,
       });
       logActivity({
         projectId,
@@ -129,7 +130,7 @@ export function useBoard(projectId: string | null) {
 
   // Update list
   const editList = useCallback(
-    async (listId: string, data: { name?: string; color?: string; autoCompleteOnEnter?: boolean; autoUncompleteOnExit?: boolean }) => {
+    async (listId: string, data: { name?: string; color?: string; autoCompleteOnEnter?: boolean; autoUncompleteOnExit?: boolean; autoSetStartDateOnEnter?: boolean }) => {
       if (!projectId) return;
       await updateList(projectId, listId, data);
     },
@@ -168,6 +169,11 @@ export function useBoard(projectId: string | null) {
             updateData.completedAt = null;
           }
 
+          // Apply auto-set-start-date logic
+          if (targetList?.autoSetStartDateOnEnter && !task.startDate) {
+            updateData.startDate = new Date();
+          }
+
           return updateTask(projectId, task.id, updateData);
         });
         await Promise.all(moveUpdates);
@@ -203,6 +209,7 @@ export function useBoard(projectId: string | null) {
       // Check if the target list has auto-complete enabled
       const targetList = state.lists.find((l) => l.id === listId);
       const shouldAutoComplete = targetList?.autoCompleteOnEnter ?? false;
+      const shouldSetStartDate = targetList?.autoSetStartDateOnEnter ?? false;
 
       await createTask(projectId, {
         listId,
@@ -214,7 +221,7 @@ export function useBoard(projectId: string | null) {
         tagIds: [],
         dependsOnTaskIds: [],
         priority: null,
-        startDate: null,
+        startDate: shouldSetStartDate ? new Date() : null,
         dueDate: null,
         durationDays: null,
         isDueDateFixed: false,
@@ -409,6 +416,7 @@ export function useBoard(projectId: string | null) {
       const oldOrder = task?.order;
       const oldIsCompleted = task?.isCompleted;
       const oldCompletedAt = task?.completedAt;
+      const oldStartDate = task?.startDate;
 
       // Prepare update data
       const updateData: Partial<Task> = {
@@ -428,6 +436,10 @@ export function useBoard(projectId: string | null) {
           updateData.isCompleted = false;
           updateData.completedAt = null;
         }
+        // Set start date on enter (only if not already set)
+        if (newList?.autoSetStartDateOnEnter && !task.startDate) {
+          updateData.startDate = new Date();
+        }
       }
 
       await updateTask(projectId, taskId, updateData);
@@ -446,6 +458,7 @@ export function useBoard(projectId: string | null) {
               order: oldOrder,
               isCompleted: oldIsCompleted,
               completedAt: oldCompletedAt,
+              startDate: oldStartDate,
             });
           },
           redo: async () => {

--- a/src/lib/firebase/admin-projects.ts
+++ b/src/lib/firebase/admin-projects.ts
@@ -24,6 +24,7 @@ interface AdminList {
   name: string;
   order: number;
   autoCompleteOnEnter?: boolean;
+  autoSetStartDateOnEnter?: boolean;
 }
 
 function omitUndefinedFields<T extends Record<string, unknown>>(data: T): T {
@@ -104,6 +105,7 @@ export interface ProjectListSummaryItem {
   order: number;
   autoCompleteOnEnter: boolean;
   autoUncompleteOnExit: boolean;
+  autoSetStartDateOnEnter: boolean;
 }
 
 export interface CreateProjectTaskInput {
@@ -255,6 +257,7 @@ async function getProjectListsInternal(projectId: string): Promise<AdminList[]> 
       name: typeof data.name === 'string' ? data.name : '',
       order: typeof data.order === 'number' ? data.order : 0,
       autoCompleteOnEnter: data.autoCompleteOnEnter === true,
+      autoSetStartDateOnEnter: data.autoSetStartDateOnEnter === true,
     };
   });
 }
@@ -272,6 +275,7 @@ export async function listProjectLists(projectId: string): Promise<ProjectListSu
       order: typeof data.order === 'number' ? data.order : 0,
       autoCompleteOnEnter: data.autoCompleteOnEnter === true,
       autoUncompleteOnExit: data.autoUncompleteOnExit === true,
+      autoSetStartDateOnEnter: data.autoSetStartDateOnEnter === true,
     };
   });
 }
@@ -467,6 +471,11 @@ export async function createProjectTask(
   const maxOrder = Math.max(...tasksInList.map((task) => task.order), -1);
   const shouldAutoComplete = targetList.autoCompleteOnEnter === true;
   const now = new Date();
+
+  // Set start date on enter (only if not already set)
+  if (targetList.autoSetStartDateOnEnter === true && !calculatedStartDate) {
+    calculatedStartDate = now;
+  }
 
   const taskData: Omit<Task, 'id' | 'projectId'> = {
     listId: input.listId,

--- a/src/lib/firebase/firestore.ts
+++ b/src/lib/firebase/firestore.ts
@@ -52,6 +52,7 @@ function convertDoc<T>(doc: DocumentData, id: string): T {
     // Default values for List fields (for backward compatibility)
     autoCompleteOnEnter: data.autoCompleteOnEnter ?? false,
     autoUncompleteOnExit: data.autoUncompleteOnExit ?? false,
+    autoSetStartDateOnEnter: data.autoSetStartDateOnEnter ?? false,
     // Default values for Task fields (for backward compatibility)
     completedAt: data.completedAt ? toDate(data.completedAt) : null,
     isAbandoned: data.isAbandoned ?? false,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -51,6 +51,7 @@ export interface List {
   order: number;
   autoCompleteOnEnter: boolean; // Mark tasks as complete when entering this list
   autoUncompleteOnExit: boolean; // Remove completion when tasks leave this list
+  autoSetStartDateOnEnter: boolean; // Set task startDate when entering this list (only if not already set)
   createdAt: Date;
   updatedAt: Date;
 }


### PR DESCRIPTION
## 概要
リストのオプション（ここに入ったら完了／ここから出たら完了を外す）に、**「ここに入ったら開始日を設定」**（startDate が未設定の場合のみ）を追加。

## 変更内容
- `List` 型に `autoSetStartDateOnEnter: boolean` を追加（Firestore 読み取り時は `?? false` で後方互換）
- リストのドロップダウンメニューにトグル項目を追加（CalendarPlus アイコン、ON表示）
- 適用箇所（既存の autoCompleteOnEnter と同じ4箇所）:
  - D&D で別リストへ移動時（Undo で元の startDate に復元）
  - タスク新規作成時
  - リスト削除時のタスク退避先
  - サーバー側 API 経由のタスク作成（`createProjectTask`。依存タスク等から開始日が算出されない場合のみ）
- シードスクリプト・テストモックにフィールド追加

## テスト
- ユニットテスト: BoardList.test.tsx 2件パス
- Playwright E2E フルスイート: 9 passed / 12 skipped（skip はテストユーザーにプロジェクトがない環境要因、従来どおり）
- 新規 E2E テストを board.spec.ts に追加（オプションのトグル → ON 表示確認 → タスク作成）

🤖 Generated with [Claude Code](https://claude.com/claude-code)