### PR TITLE
タスクカードの日付とステータスを見やすくする

### DIFF
--- a/src/components/board/BoardList.test.tsx
+++ b/src/components/board/BoardList.test.tsx
@@ -24,7 +24,11 @@ vi.mock('@dnd-kit/core', () => ({
 }));
 
 vi.mock('./TaskCard', () => ({
-  TaskCard: ({ task }: { task: Task }) => <div>{task.title}</div>,
+  TaskCard: ({ task, listName, listColor }: { task: Task; listName: string; listColor: string }) => (
+    <div data-testid="mock-task-card" data-list-name={listName} data-list-color={listColor}>
+      {task.title}
+    </div>
+  ),
 }));
 
 const list: List = {
@@ -68,6 +72,26 @@ const task: Task = {
 };
 
 describe('BoardList', () => {
+  it('passes the list status presentation to each task card', () => {
+    render(
+      <BoardList
+        projectId="project-1"
+        list={list}
+        tasks={[task]}
+        allTasks={[task]}
+        labels={[]}
+        tags={[]}
+        onAddTask={vi.fn()}
+        onEditList={vi.fn()}
+        onDeleteList={vi.fn()}
+        onTaskClick={vi.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('mock-task-card')).toHaveAttribute('data-list-name', '依頼事項');
+    expect(screen.getByTestId('mock-task-card')).toHaveAttribute('data-list-color', '#8b5cf6');
+  });
+
   it('keeps the task composer at the bottom when launched from the bottom add button', () => {
     const onAddTask = vi.fn();
 

--- a/src/components/board/BoardList.tsx
+++ b/src/components/board/BoardList.tsx
@@ -292,6 +292,8 @@ export function BoardList({
                   key={task.id}
                   projectId={projectId}
                   task={task}
+                  listName={list.name}
+                  listColor={list.color}
                   labels={labels}
                   tags={tags}
                   allTasks={allTasks}

--- a/src/components/board/BoardView.tsx
+++ b/src/components/board/BoardView.tsx
@@ -158,6 +158,9 @@ export function BoardView({ projectId, onTaskClick, filters }: BoardViewProps) {
 
   // Use local lists for rendering (optimistic updates)
   const displayLists = localLists.length > 0 ? localLists : lists;
+  const activeTaskList = activeTask
+    ? displayLists.find((list) => list.id === activeTask.listId)
+    : null;
 
   // Delete list dialog state
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -509,6 +512,8 @@ export function BoardView({ projectId, onTaskClick, filters }: BoardViewProps) {
           <TaskCard
             projectId={projectId}
             task={activeTask}
+            listName={activeTaskList?.name ?? ''}
+            listColor={activeTaskList?.color ?? '#64748b'}
             labels={labels.filter((l) => activeTask.labelIds.includes(l.id))}
             tags={tags.filter((t) => activeTask.tagIds?.includes(t.id))}
             allTasks={tasks}

--- a/src/components/board/TaskCard.test.tsx
+++ b/src/components/board/TaskCard.test.tsx
@@ -1,0 +1,137 @@
+import type { ReactNode } from 'react';
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { TaskCard } from './TaskCard';
+import type { Label, Tag, Task } from '@/types';
+
+vi.mock('@dnd-kit/sortable', () => ({
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: () => undefined,
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+  }),
+}));
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => (
+    <div data-testid="task-card-hover-details">{children}</div>
+  ),
+}));
+
+vi.mock('@/lib/firebase/firestore', () => ({
+  getUsersByIds: vi.fn().mockResolvedValue([]),
+  getTaskAttachments: vi.fn().mockResolvedValue([]),
+  getProject: vi.fn().mockResolvedValue({ name: 'プロジェクト' }),
+}));
+
+vi.mock('@/hooks/useNotifications', () => ({
+  useNotifications: () => ({ sendBellNotification: vi.fn() }),
+}));
+
+const baseTask: Task = {
+  id: 'task-1',
+  projectId: 'project-1',
+  listId: 'list-1',
+  title: 'タスクカードの日付とステータスを見やすくするための長いタイトル',
+  description: 'ホバーで表示する詳細です',
+  order: 0,
+  assigneeIds: [],
+  labelIds: ['label-1'],
+  tagIds: ['tag-1'],
+  dependsOnTaskIds: [],
+  priority: 'high',
+  startDate: new Date('2026-07-15T00:00:00.000Z'),
+  dueDate: new Date('2026-07-18T00:00:00.000Z'),
+  durationDays: null,
+  isDueDateFixed: false,
+  isCompleted: false,
+  completedAt: null,
+  isAbandoned: false,
+  isArchived: false,
+  archivedAt: null,
+  archivedBy: null,
+  createdBy: 'user-1',
+  createdAt: new Date('2026-07-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-07-01T00:00:00.000Z'),
+};
+
+const labels: Label[] = [{
+  id: 'label-1',
+  projectId: 'project-1',
+  name: 'デザイン',
+  color: '#7c3aed',
+  createdAt: new Date('2026-07-01T00:00:00.000Z'),
+}];
+
+const tags: Tag[] = [{
+  id: 'tag-1',
+  projectId: 'project-1',
+  name: 'UI改善',
+  color: '#0891b2',
+  order: 0,
+  createdAt: new Date('2026-07-01T00:00:00.000Z'),
+}];
+
+function renderTaskCard(task: Task = baseTask) {
+  return render(
+    <TaskCard
+      projectId="project-1"
+      task={task}
+      listName="進行中"
+      listColor="#2563eb"
+      labels={labels}
+      tags={tags}
+      allTasks={[task]}
+      onClick={vi.fn()}
+    />
+  );
+}
+
+describe('TaskCard', () => {
+  it('shows the date rail and keeps the summary compact', () => {
+    renderTaskCard();
+
+    const card = screen.getByTestId('task-card');
+    const dateRail = within(card).getByTestId('task-card-date-rail');
+    const title = within(card).getByText(baseTask.title);
+
+    expect(dateRail).toHaveTextContent('7/15〜7/18');
+    expect(title).toHaveClass('line-clamp-2');
+    expect(within(card).getByText('高')).toBeInTheDocument();
+    expect(within(card).getByText('進行中')).toBeInTheDocument();
+    expect(within(card).queryByText(baseTask.description)).not.toBeInTheDocument();
+    expect(within(card).queryByText('デザイン')).not.toBeInTheDocument();
+    expect(within(card).queryByText('UI改善')).not.toBeInTheDocument();
+  });
+
+  it('moves the description, labels, and tags into hover details', () => {
+    renderTaskCard();
+
+    const details = screen.getByTestId('task-card-hover-details');
+
+    expect(within(details).getByText(baseTask.description)).toBeInTheDocument();
+    expect(within(details).getByText('デザイン')).toBeInTheDocument();
+    expect(within(details).getByText('UI改善')).toBeInTheDocument();
+  });
+
+  it('uses the full content width when neither date is set', () => {
+    renderTaskCard({
+      ...baseTask,
+      startDate: null,
+      dueDate: null,
+      description: '',
+      labelIds: [],
+      tagIds: [],
+    });
+
+    const card = screen.getByTestId('task-card');
+
+    expect(within(card).queryByTestId('task-card-date-rail')).not.toBeInTheDocument();
+    expect(within(card).getByText('進行中')).toBeInTheDocument();
+  });
+});

--- a/src/components/board/TaskCard.tsx
+++ b/src/components/board/TaskCard.tsx
@@ -19,7 +19,6 @@ import {
 import {
   Tooltip,
   TooltipContent,
-  TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
@@ -31,6 +30,8 @@ import { isTaskOverdue, getEffectiveDates } from '@/lib/utils/task';
 interface TaskCardProps {
   projectId: string;
   task: Task;
+  listName: string;
+  listColor: string;
   labels: Label[];
   tags: Tag[];
   allTasks?: Task[]; // For dependency lookup
@@ -38,7 +39,7 @@ interface TaskCardProps {
   isDragging?: boolean;
 }
 
-export function TaskCard({ projectId, task, labels, tags, allTasks, onClick, isDragging }: TaskCardProps) {
+export function TaskCard({ projectId, task, listName, listColor, labels, tags, allTasks, onClick, isDragging }: TaskCardProps) {
   const [assignees, setAssignees] = useState<UserType[]>([]);
   const [imageAttachments, setImageAttachments] = useState<Attachment[]>([]);
   const [bellMessage, setBellMessage] = useState('');
@@ -148,7 +149,36 @@ export function TaskCard({ projectId, task, labels, tags, allTasks, onClick, isD
       .slice(0, 2);
   };
 
-  return (
+  const hasDateRail = Boolean(task.startDate || task.dueDate);
+  const hasHoverDetails = Boolean(
+    task.description ||
+    taskLabels.length > 0 ||
+    taskTags.length > 0 ||
+    task.completedAt ||
+    hasDateRail ||
+    task.durationDays ||
+    hasDependencies ||
+    isDeadlineOverdue ||
+    predictedDates
+  );
+
+  const renderRailDate = (date: Date) => {
+    const text = format(date, 'M/d', { locale: ja });
+
+    return (
+      <time
+        dateTime={format(date, 'yyyy-MM-dd')}
+        className={cn(
+          'whitespace-nowrap font-bold leading-none tracking-[-0.04em]',
+          text.length >= 5 ? 'text-[17px]' : 'text-[20px]'
+        )}
+      >
+        {text}
+      </time>
+    );
+  };
+
+  const card = (
     <div
       ref={setNodeRef}
       style={style}
@@ -157,7 +187,7 @@ export function TaskCard({ projectId, task, labels, tags, allTasks, onClick, isD
       onClick={onClick}
       data-testid="task-card"
       className={cn(
-        'group cursor-pointer rounded-lg border bg-white shadow-sm transition-shadow hover:shadow-md',
+        'group cursor-pointer overflow-hidden rounded-lg border bg-white shadow-sm transition-shadow hover:shadow-md',
         (isDragging || isSortableDragging) && 'opacity-50 shadow-lg',
         isDeadlineOverdue && 'border-red-500 border-2 bg-red-50'
       )}
@@ -202,267 +232,146 @@ export function TaskCard({ projectId, task, labels, tags, allTasks, onClick, isD
         </div>
       )}
 
-      <div className="p-3">
-        {/* Labels */}
-        {taskLabels.length > 0 && (
-          <div className="mb-2 flex flex-wrap gap-1">
+      <div className="flex">
+        {hasDateRail && (
+          <aside
+            data-testid="task-card-date-rail"
+            className={cn(
+              'flex w-14 shrink-0 flex-col items-center justify-center gap-2 border-r border-blue-200 bg-blue-50 px-1.5 py-3 text-slate-950',
+              isOverdue && 'border-red-200 bg-red-50 text-red-700'
+            )}
+          >
+            {task.startDate && renderRailDate(task.startDate)}
+            {task.startDate && task.dueDate && (
+              <span className="text-[20px] font-bold leading-none tracking-[-0.04em]" aria-hidden="true">
+                〜
+              </span>
+            )}
+            {task.dueDate && renderRailDate(task.dueDate)}
+          </aside>
+        )}
+
+        <div className="min-w-0 flex-1 p-3">
+          <div className="flex items-start gap-2">
+            <p className="line-clamp-2 min-w-0 flex-1 text-sm font-semibold leading-5 text-slate-950">
+              {task.title}
+            </p>
+            <Popover open={isBellOpen} onOpenChange={setIsBellOpen}>
+              <PopoverTrigger asChild>
+                <button
+                  type="button"
+                  aria-label="メンバーに通知"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setIsBellOpen(true);
+                  }}
+                  className="mt-0.5 shrink-0 rounded p-1 text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground group-hover:opacity-100 focus:opacity-100"
+                >
+                  <Bell className="h-3.5 w-3.5" />
+                </button>
+              </PopoverTrigger>
+              <PopoverContent
+                className="z-50 w-64 border bg-background shadow-lg"
+                align="end"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <div className="space-y-2">
+                  <p className="text-sm font-medium">メンバーに通知</p>
+                  <Input
+                    value={bellMessage}
+                    onChange={(e) => setBellMessage(e.target.value)}
+                    placeholder="メッセージ（任意）"
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
+                        handleSendBellNotification();
+                      }
+                    }}
+                  />
+                  <Button
+                    size="sm"
+                    className="w-full"
+                    onClick={handleSendBellNotification}
+                    disabled={isSendingBell}
+                  >
+                    {isSendingBell ? '送信中...' : '通知を送信'}
+                  </Button>
+                </div>
+              </PopoverContent>
+            </Popover>
+          </div>
+
+          <div className="mt-2 flex min-h-6 items-center justify-between gap-2">
+            <div className="flex -space-x-1.5">
+              {assignees.slice(0, 4).map((assignee) => (
+                <Avatar key={assignee.id} className="h-6 w-6 border-2 border-white">
+                  <AvatarImage src={assignee.photoURL || ''} alt={assignee.displayName} />
+                  <AvatarFallback className="text-[9px]">
+                    {getInitials(assignee.displayName)}
+                  </AvatarFallback>
+                </Avatar>
+              ))}
+              {assignees.length > 4 && (
+                <div className="flex h-6 w-6 items-center justify-center rounded-full border-2 border-white bg-muted text-[9px] font-medium">
+                  +{assignees.length - 4}
+                </div>
+              )}
+            </div>
+
+            <div className="flex min-w-0 items-center justify-end gap-1">
+              {task.priority && (
+                <Badge
+                  variant="outline"
+                  className={cn(
+                    'h-5 shrink-0 px-1.5 text-[10px]',
+                    task.priority === 'high' && 'border-red-300 bg-red-50 text-red-700',
+                    task.priority === 'medium' && 'border-yellow-300 bg-yellow-50 text-yellow-700',
+                    task.priority === 'low' && 'border-gray-300 bg-gray-50 text-gray-700'
+                  )}
+                >
+                  {task.priority === 'high' ? '高' : task.priority === 'medium' ? '中' : '低'}
+                </Badge>
+              )}
+              <Badge
+                variant="outline"
+                className="h-5 max-w-[92px] shrink px-1.5 text-[9px] font-semibold"
+                style={{
+                  borderColor: listColor,
+                  color: listColor,
+                  backgroundColor: `${listColor}18`,
+                }}
+              >
+                <span className="truncate">{listName}</span>
+              </Badge>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+
+  if (!hasHoverDetails || isDragging || isSortableDragging) {
+    return card;
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{card}</TooltipTrigger>
+      <TooltipContent side="top" sideOffset={8} className="w-72 max-w-[calc(100vw-2rem)] space-y-2 px-3 py-2.5 text-left text-xs text-balance">
+        <p className="font-semibold">詳細</p>
+
+        {task.description && <p className="whitespace-pre-wrap text-background/85">{task.description}</p>}
+
+        {(taskLabels.length > 0 || taskTags.length > 0) && (
+          <div className="flex flex-wrap gap-1">
             {taskLabels.map((label) => (
               <Badge
                 key={label.id}
-                variant="outline"
-                className="h-5 px-1.5 text-[10px]"
-                style={{
-                  borderColor: label.color,
-                  color: label.color,
-                  backgroundColor: `${label.color}15`,
-                }}
+                className="h-5 px-1.5 text-[10px] text-white"
+                style={{ backgroundColor: label.color }}
               >
                 {label.name}
               </Badge>
             ))}
-          </div>
-        )}
-
-        {/* Title Row with Bell */}
-        <div className="flex items-start justify-between gap-2">
-          <p className="flex-1 text-sm font-medium">
-            {task.title}
-          </p>
-          <Popover open={isBellOpen} onOpenChange={setIsBellOpen}>
-            <PopoverTrigger asChild>
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setIsBellOpen(true);
-                }}
-                className="flex-shrink-0 rounded p-1 text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground group-hover:opacity-100"
-              >
-                <Bell className="h-3.5 w-3.5" />
-              </button>
-            </PopoverTrigger>
-            <PopoverContent
-              className="w-64 bg-background border shadow-lg z-50"
-              align="end"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <div className="space-y-2">
-                <p className="text-sm font-medium">メンバーに通知</p>
-                <Input
-                  value={bellMessage}
-                  onChange={(e) => setBellMessage(e.target.value)}
-                  placeholder="メッセージ（任意）"
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
-                      handleSendBellNotification();
-                    }
-                  }}
-                />
-                <Button
-                  size="sm"
-                  className="w-full"
-                  onClick={handleSendBellNotification}
-                  disabled={isSendingBell}
-                >
-                  {isSendingBell ? '送信中...' : '通知を送信'}
-                </Button>
-              </div>
-            </PopoverContent>
-          </Popover>
-        </div>
-
-        {/* Description - truncated */}
-        {task.description && (
-          <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">
-            {task.description}
-          </p>
-        )}
-
-        {/* Assignees Row */}
-        {assignees.length > 0 && (
-          <div className="mt-2 flex -space-x-1.5">
-            {assignees.slice(0, 4).map((assignee) => (
-              <Avatar key={assignee.id} className="h-6 w-6 border-2 border-white">
-                <AvatarImage src={assignee.photoURL || ''} alt={assignee.displayName} />
-                <AvatarFallback className="text-[9px]">
-                  {getInitials(assignee.displayName)}
-                </AvatarFallback>
-              </Avatar>
-            ))}
-            {assignees.length > 4 && (
-              <div className="flex h-6 w-6 items-center justify-center rounded-full border-2 border-white bg-muted text-[9px] font-medium">
-                +{assignees.length - 4}
-              </div>
-            )}
-          </div>
-        )}
-
-        {/* Metadata Row */}
-        {(task.startDate || task.dueDate || task.priority || task.completedAt) && (
-          <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-            {/* Completion Date - shown when completed */}
-            {task.isCompleted && task.completedAt && (
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <div className="flex items-center gap-1 text-green-600 cursor-default">
-                      <CheckCircle2 className="h-3 w-3" />
-                      <span>完了: {format(task.completedAt, 'M/d', { locale: ja })}</span>
-                    </div>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <p>{format(task.completedAt, 'yyyy年M月d日', { locale: ja })}</p>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            )}
-
-            {/* Date Range - not shown as overdue if completed */}
-            {!task.isCompleted && (task.startDate || task.dueDate) && (
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <div
-                      className={cn(
-                        'flex items-center gap-1 cursor-default',
-                        isOverdue && 'text-red-500'
-                      )}
-                    >
-                      <Calendar className="h-3 w-3" />
-                      <span>
-                        {task.startDate && format(task.startDate, 'M/d', { locale: ja })}
-                        {task.startDate && task.dueDate && ' - '}
-                        {task.dueDate && format(task.dueDate, 'M/d', { locale: ja })}
-                      </span>
-                    </div>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <p>
-                      {task.startDate && format(task.startDate, 'yyyy年M月d日', { locale: ja })}
-                      {task.startDate && task.dueDate && ' 〜 '}
-                      {task.dueDate && format(task.dueDate, 'yyyy年M月d日', { locale: ja })}
-                    </p>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            )}
-
-            {/* Priority Badge */}
-            {task.priority && (
-              <Badge
-                variant="outline"
-                className={cn(
-                  'h-5 px-1.5 text-[10px]',
-                  task.priority === 'high' && 'border-red-300 bg-red-50 text-red-700',
-                  task.priority === 'medium' && 'border-yellow-300 bg-yellow-50 text-yellow-700',
-                  task.priority === 'low' && 'border-gray-300 bg-gray-50 text-gray-700'
-                )}
-              >
-                {task.priority === 'high' ? '高' : task.priority === 'medium' ? '中' : '低'}
-              </Badge>
-            )}
-          </div>
-        )}
-
-        {/* Dependencies and Duration Row */}
-        {(hasDependencies || task.durationDays || isDeadlineOverdue) && (
-          <div className="mt-2 flex flex-wrap items-center gap-2 text-xs">
-            {/* Deadline Overdue Warning */}
-            {isDeadlineOverdue && (
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <div className="flex items-center gap-1 text-red-600 font-medium cursor-default">
-                      <AlertTriangle className="h-3 w-3" />
-                      <span>期限超過</span>
-                    </div>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <p>依存タスクの遅延により、開始日が期限を超過しています</p>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            )}
-
-            {/* Duration Badge */}
-            {task.durationDays && (
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <div className="flex items-center gap-1 text-blue-600 cursor-default">
-                      <Clock className="h-3 w-3" />
-                      <span>{task.durationDays}日間</span>
-                    </div>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <p>必要期間: {task.durationDays}日</p>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            )}
-
-            {/* Dependencies */}
-            {hasDependencies && (
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <div className="flex items-center gap-1 text-purple-600 cursor-default">
-                      <Link2 className="h-3 w-3" />
-                      <span className="truncate max-w-[100px]">
-                        {dependentTasks[0].title}
-                        {dependentTasks.length > 1 && ` 他${dependentTasks.length - 1}件`}
-                        後
-                      </span>
-                    </div>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <div className="space-y-1">
-                      <p className="font-medium">依存タスク:</p>
-                      {dependentTasks.map((dep) => (
-                        <p key={dep.id} className="flex items-center gap-1">
-                          {dep.isCompleted ? (
-                            <CheckCircle2 className="h-3 w-3 text-green-500" />
-                          ) : (
-                            <span className="h-3 w-3 rounded-full border border-gray-300" />
-                          )}
-                          <span className={dep.isCompleted ? 'line-through text-muted-foreground' : ''}>
-                            {dep.title}
-                          </span>
-                        </p>
-                      ))}
-                    </div>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            )}
-
-            {/* Predicted Dates */}
-            {predictedDates && !task.startDate && !task.dueDate && (
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <div className="flex items-center gap-1 text-amber-600 cursor-default">
-                      <Calendar className="h-3 w-3" />
-                      <span>
-                        予測: {format(predictedDates.start, 'M/d', { locale: ja })}〜{format(predictedDates.end, 'M/d', { locale: ja })}
-                      </span>
-                    </div>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <p>
-                      依存タスク完了後の予測日程:
-                      <br />
-                      {format(predictedDates.start, 'yyyy年M月d日', { locale: ja })} 〜 {format(predictedDates.end, 'yyyy年M月d日', { locale: ja })}
-                    </p>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            )}
-          </div>
-        )}
-
-        {/* Tags - displayed at bottom like Jooto */}
-        {taskTags.length > 0 && (
-          <div className="mt-2 flex flex-wrap gap-1">
             {taskTags.map((tag) => (
               <Badge
                 key={tag.id}
@@ -474,7 +383,66 @@ export function TaskCard({ projectId, task, labels, tags, allTasks, onClick, isD
             ))}
           </div>
         )}
-      </div>
-    </div>
+
+        <div className="space-y-1 text-background/85">
+          {hasDateRail && (
+            <p className="flex items-center gap-1">
+              <Calendar className="h-3 w-3 shrink-0" />
+              <span>
+                {task.startDate && format(task.startDate, 'yyyy年M月d日', { locale: ja })}
+                {task.startDate && task.dueDate && ' 〜 '}
+                {task.dueDate && format(task.dueDate, 'yyyy年M月d日', { locale: ja })}
+              </span>
+            </p>
+          )}
+          {task.isCompleted && task.completedAt && (
+            <p className="flex items-center gap-1 text-green-300">
+              <CheckCircle2 className="h-3 w-3 shrink-0" />
+              <span>完了: {format(task.completedAt, 'yyyy年M月d日', { locale: ja })}</span>
+            </p>
+          )}
+          {task.durationDays && (
+            <p className="flex items-center gap-1">
+              <Clock className="h-3 w-3 shrink-0" />
+              <span>必要期間: {task.durationDays}日</span>
+            </p>
+          )}
+          {isDeadlineOverdue && (
+            <p className="flex items-center gap-1 text-red-300">
+              <AlertTriangle className="h-3 w-3 shrink-0" />
+              <span>依存タスクの遅延により期限超過</span>
+            </p>
+          )}
+          {predictedDates && !task.startDate && !task.dueDate && (
+            <p className="flex items-center gap-1 text-amber-200">
+              <Calendar className="h-3 w-3 shrink-0" />
+              <span>
+                予測: {format(predictedDates.start, 'M/d', { locale: ja })}〜{format(predictedDates.end, 'M/d', { locale: ja })}
+              </span>
+            </p>
+          )}
+        </div>
+
+        {hasDependencies && (
+          <div className="space-y-1 border-t border-background/20 pt-2 text-background/85">
+            <p className="flex items-center gap-1 font-medium text-background">
+              <Link2 className="h-3 w-3" />依存タスク
+            </p>
+            {dependentTasks.map((dep) => (
+              <p key={dep.id} className="flex items-center gap-1 pl-4">
+                {dep.isCompleted ? (
+                  <CheckCircle2 className="h-3 w-3 shrink-0 text-green-300" />
+                ) : (
+                  <span className="h-3 w-3 shrink-0 rounded-full border border-background/50" />
+                )}
+                <span className={cn('truncate', dep.isCompleted && 'line-through opacity-70')}>
+                  {dep.title}
+                </span>
+              </p>
+            ))}
+          </div>
+        )}
+      </TooltipContent>
+    </Tooltip>
   );
 }


### PR DESCRIPTION
Closes #78

## 変更内容

- タスクカード左側へ開始日と期日を大きく配置
- タイトルを最大2行で省略
- 優先度と所属リスト名を右下へ配置
- 説明、ラベル、タグ、期間、依存情報をホバー詳細へ移動
- 日付なし、片側日付、期限超過、画像、ドラッグ表示を維持
- TaskCardとBoardListのテストを追加

## 利用者への影響

日付とステータスをカード上で素早く確認でき、詳細情報は必要なときだけホバーで確認できます。

## 検証

- npm run audit
- npm run lint
- npm run test:run: 158 passed
- npm run build
- npm run test:e2e:smoke: clean worktreeで6 passed
- デモボードでホバー表示とカードクリックを目視確認