### PR TITLE
タスクを右クリックで別の看板へ移動できるようにする

### DIFF
--- a/src/components/board/BoardList.test.tsx
+++ b/src/components/board/BoardList.test.tsx
@@ -24,7 +24,20 @@ vi.mock('@dnd-kit/core', () => ({
 }));
 
 vi.mock('./TaskCard', () => ({
-  TaskCard: ({ task }: { task: Task }) => <div>{task.title}</div>,
+  TaskCard: ({
+    task,
+    onClick,
+    onMove,
+  }: {
+    task: Task;
+    onClick: () => void;
+    onMove: (listId: string) => void;
+  }) => (
+    <div>
+      <button onClick={onClick}>{task.title}</button>
+      <button onClick={() => onMove('list-2')}>別の看板へ移動</button>
+    </div>
+  ),
 }));
 
 const list: List = {
@@ -83,6 +96,8 @@ describe('BoardList', () => {
         onEditList={vi.fn()}
         onDeleteList={vi.fn()}
         onTaskClick={vi.fn()}
+        allLists={[list]}
+        onTaskMove={vi.fn()}
       />
     );
 
@@ -117,6 +132,8 @@ describe('BoardList', () => {
         onEditList={vi.fn()}
         onDeleteList={vi.fn()}
         onTaskClick={vi.fn()}
+        allLists={[list]}
+        onTaskMove={vi.fn()}
       />
     );
 
@@ -128,5 +145,33 @@ describe('BoardList', () => {
     fireEvent.click(screen.getByRole('button', { name: '追加' }));
 
     expect(onAddTask).toHaveBeenCalledWith('先頭で追加するタスク', 'top');
+  });
+
+  it('keeps normal task clicks and routes context-menu moves with the task id', () => {
+    const onTaskClick = vi.fn();
+    const onTaskMove = vi.fn();
+
+    render(
+      <BoardList
+        projectId="project-1"
+        list={list}
+        tasks={[task]}
+        allTasks={[task]}
+        labels={[]}
+        tags={[]}
+        onAddTask={vi.fn()}
+        onEditList={vi.fn()}
+        onDeleteList={vi.fn()}
+        onTaskClick={onTaskClick}
+        allLists={[list]}
+        onTaskMove={onTaskMove}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '既存タスク' }));
+    fireEvent.click(screen.getByRole('button', { name: '別の看板へ移動' }));
+
+    expect(onTaskClick).toHaveBeenCalledWith('task-1');
+    expect(onTaskMove).toHaveBeenCalledWith('task-1', 'list-2');
   });
 });

--- a/src/components/board/BoardList.tsx
+++ b/src/components/board/BoardList.tsx
@@ -44,6 +44,8 @@ interface BoardListProps {
   onEditList: (data: { name?: string; color?: string; autoCompleteOnEnter?: boolean; autoUncompleteOnExit?: boolean; autoSetStartDateOnEnter?: boolean }) => void;
   onDeleteList: () => void;
   onTaskClick: (taskId: string) => void;
+  allLists: List[];
+  onTaskMove: (taskId: string, listId: string) => void;
 }
 
 export function BoardList({
@@ -57,6 +59,8 @@ export function BoardList({
   onEditList,
   onDeleteList,
   onTaskClick,
+  allLists,
+  onTaskMove,
 }: BoardListProps) {
   const [taskComposerPosition, setTaskComposerPosition] = useState<'top' | 'bottom' | null>(null);
   const [newTaskTitle, setNewTaskTitle] = useState('');
@@ -296,6 +300,8 @@ export function BoardList({
                   tags={tags}
                   allTasks={allTasks}
                   onClick={() => onTaskClick(task.id)}
+                  lists={allLists}
+                  onMove={(targetListId) => onTaskMove(task.id, targetListId)}
                 />
               ))}
             </SortableContext>

--- a/src/components/board/BoardView.tsx
+++ b/src/components/board/BoardView.tsx
@@ -367,6 +367,14 @@ export function BoardView({ projectId, onTaskClick, filters }: BoardViewProps) {
     }
   };
 
+  const handleTaskMove = useCallback(
+    (taskId: string, targetListId: string) => {
+      const tasksInTargetList = getTasksByListId(targetListId);
+      moveTask(taskId, targetListId, tasksInTargetList.length);
+    },
+    [getTasksByListId, moveTask]
+  );
+
   const handleDeleteListRequest = (list: List) => {
     const tasksInList = getTasksByListId(list.id);
     if (tasksInList.length === 0) {
@@ -435,6 +443,8 @@ export function BoardView({ projectId, onTaskClick, filters }: BoardViewProps) {
                 onEditList={(data) => editList(list.id, data)}
                 onDeleteList={() => handleDeleteListRequest(list)}
                 onTaskClick={onTaskClick}
+                allLists={displayLists}
+                onTaskMove={handleTaskMove}
               />
             ))}
           </SortableContext>

--- a/src/components/board/TaskCard.tsx
+++ b/src/components/board/TaskCard.tsx
@@ -6,7 +6,7 @@ import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { format } from 'date-fns';
 import { ja } from 'date-fns/locale';
-import { AlertTriangle, Calendar, Bell, CheckCircle2, Clock, Link2 } from 'lucide-react';
+import { AlertTriangle, Calendar, Bell, CheckCircle2, Clock, Link2, MoveRight } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
@@ -22,10 +22,19 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
+  ContextMenuTrigger,
+} from '@/components/ui/context-menu';
 import { cn } from '@/lib/utils';
 import { getUsersByIds, getTaskAttachments, getProject } from '@/lib/firebase/firestore';
 import { useNotifications } from '@/hooks/useNotifications';
-import type { Task, Label, Tag, User as UserType, Attachment } from '@/types';
+import type { Task, Label, Tag, User as UserType, Attachment, List } from '@/types';
 import { isTaskOverdue, getEffectiveDates } from '@/lib/utils/task';
 
 interface TaskCardProps {
@@ -35,10 +44,12 @@ interface TaskCardProps {
   tags: Tag[];
   allTasks?: Task[]; // For dependency lookup
   onClick: () => void;
+  lists?: List[];
+  onMove?: (listId: string) => void;
   isDragging?: boolean;
 }
 
-export function TaskCard({ projectId, task, labels, tags, allTasks, onClick, isDragging }: TaskCardProps) {
+export function TaskCard({ projectId, task, labels, tags, allTasks, onClick, lists = [], onMove, isDragging }: TaskCardProps) {
   const [assignees, setAssignees] = useState<UserType[]>([]);
   const [imageAttachments, setImageAttachments] = useState<Attachment[]>([]);
   const [bellMessage, setBellMessage] = useState('');
@@ -148,7 +159,9 @@ export function TaskCard({ projectId, task, labels, tags, allTasks, onClick, isD
       .slice(0, 2);
   };
 
-  return (
+  const moveTargets = lists.filter((list) => list.id !== task.listId);
+
+  const card = (
     <div
       ref={setNodeRef}
       style={style}
@@ -476,5 +489,30 @@ export function TaskCard({ projectId, task, labels, tags, allTasks, onClick, isD
         )}
       </div>
     </div>
+  );
+
+  if (!onMove || moveTargets.length === 0 || isDragging) {
+    return card;
+  }
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>{card}</ContextMenuTrigger>
+      <ContextMenuContent>
+        <ContextMenuSub>
+          <ContextMenuSubTrigger>
+            <MoveRight className="mr-2 h-4 w-4" />
+            移動
+          </ContextMenuSubTrigger>
+          <ContextMenuSubContent>
+            {moveTargets.map((list) => (
+              <ContextMenuItem key={list.id} onSelect={() => onMove(list.id)}>
+                {list.name}
+              </ContextMenuItem>
+            ))}
+          </ContextMenuSubContent>
+        </ContextMenuSub>
+      </ContextMenuContent>
+    </ContextMenu>
   );
 }


### PR DESCRIPTION
## 概要

- タスクカードの右クリックメニューに「移動」サブメニューを追加
- 現在の看板を除いた移動先一覧を表示
- 既存の `moveTask` 経由で移動し、自動完了・完了解除・開始日設定を維持
- 通常クリックと右クリック移動の回帰テストを追加

Closes #80

## 検証

- `npm run audit` ✅（high 以上なし、moderate 2件は既存 Next.js 依存）
- `npm run lint` ✅
- `npm run test:run` ✅（21 files / 149 tests）
- `npm run build` ✅
- `npm run test:e2e:smoke` ✅（3 tests）