### PR TITLE
プロジェクト削除前のアーカイブを必須化する

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -71,8 +71,10 @@ service cloud.firestore {
                      (isAllowedUser() && request.auth.uid in resource.data.memberIds);
       // プロジェクトの作成は許可ドメインの全ユーザー
       allow create: if isAllowedUser();
-      // プロジェクトの更新・削除はメンバーのみ
-      allow update, delete: if canAccessProject(projectId);
+      // プロジェクトの更新はメンバーのみ
+      allow update: if canAccessProject(projectId);
+      // 誤削除防止のため、削除はアーカイブ済みプロジェクトに限定
+      allow delete: if canAccessProject(projectId) && resource.data.isArchived == true;
 
       // メンバー管理
       match /members/{memberId} {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11668,34 +11668,6 @@
         }
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -12210,7 +12182,6 @@
       "version": "8.5.14",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
       "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -14378,9 +14349,9 @@
       }
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "license": "Apache-2.0",
       "dependencies": {
         "http-parser-js": ">=0.5.1",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,8 @@
     "vitest": "^4.0.18"
   },
   "overrides": {
-    "@tootallnate/once": "3.0.1"
+    "@tootallnate/once": "3.0.1",
+    "postcss": "8.5.14",
+    "websocket-driver": "0.7.5"
   }
 }

--- a/src/app/(dashboard)/projects/[projectId]/settings/page.test.tsx
+++ b/src/app/(dashboard)/projects/[projectId]/settings/page.test.tsx
@@ -1,0 +1,108 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import ProjectSettingsPage from './page';
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  archive: vi.fn(),
+  remove: vi.fn(),
+  update: vi.fn(),
+  addMember: vi.fn(),
+  removeMember: vi.fn(),
+  updateRole: vi.fn(),
+  project: {
+    id: 'project-1',
+    name: 'テストプロジェクト',
+    description: '説明',
+    color: '#3b82f6',
+    icon: '📁',
+    urls: [],
+    isArchived: false,
+  },
+  members: [],
+}));
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ projectId: 'project-1' }),
+  useRouter: () => ({ push: mocks.push }),
+}));
+
+vi.mock('@/hooks/useProjects', () => ({
+  useProject: () => ({
+    project: mocks.project,
+    members: mocks.members,
+    isLoading: false,
+    update: mocks.update,
+    archive: mocks.archive,
+    remove: mocks.remove,
+    addMember: mocks.addMember,
+    removeMember: mocks.removeMember,
+    updateRole: mocks.updateRole,
+  }),
+}));
+
+vi.mock('@/lib/firebase/firestore', () => ({
+  getUsersByIds: vi.fn().mockResolvedValue([]),
+  getAllUsers: vi.fn(() => new Promise(() => {})),
+  subscribeToArchivedTasks: vi.fn(() => vi.fn()),
+  restoreTask: vi.fn(),
+  deleteTask: vi.fn(),
+}));
+
+vi.mock('@/lib/firebase/storage', () => ({
+  deleteProjectIcon: vi.fn(),
+  uploadProjectIconBlob: vi.fn(),
+  uploadProjectHeaderImageBlob: vi.fn(),
+  deleteProjectHeaderImage: vi.fn(),
+}));
+
+describe('ProjectSettingsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('confirm', vi.fn(() => true));
+    vi.stubGlobal('alert', vi.fn());
+    mocks.project.isArchived = false;
+  });
+
+  it('archives the project and returns to the projects page', async () => {
+    mocks.archive.mockResolvedValue(undefined);
+    render(<ProjectSettingsPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'アーカイブ' }));
+
+    expect(confirm).toHaveBeenCalledWith('このプロジェクトをアーカイブしますか？');
+    await waitFor(() => expect(mocks.archive).toHaveBeenCalledOnce());
+    expect(mocks.push).toHaveBeenCalledWith('/projects');
+  });
+
+  it('does not archive when confirmation is cancelled', () => {
+    vi.mocked(confirm).mockReturnValue(false);
+    render(<ProjectSettingsPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'アーカイブ' }));
+
+    expect(mocks.archive).not.toHaveBeenCalled();
+    expect(mocks.push).not.toHaveBeenCalled();
+  });
+
+  it('does not allow an active project to be deleted', () => {
+    render(<ProjectSettingsPage />);
+
+    expect(screen.getByRole('button', { name: '削除' })).toBeDisabled();
+    expect(screen.getByText('削除するには先にプロジェクトをアーカイブしてください')).toBeVisible();
+  });
+
+  it('deletes an archived project and returns to the projects page', async () => {
+    mocks.project.isArchived = true;
+    mocks.remove.mockResolvedValue(undefined);
+    render(<ProjectSettingsPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: '削除' }));
+
+    expect(confirm).toHaveBeenCalledWith(
+      'このプロジェクトを完全に削除しますか？この操作は取り消せません。'
+    );
+    await waitFor(() => expect(mocks.remove).toHaveBeenCalledOnce());
+    expect(mocks.push).toHaveBeenCalledWith('/projects');
+  });
+});

--- a/src/app/(dashboard)/projects/[projectId]/settings/page.tsx
+++ b/src/app/(dashboard)/projects/[projectId]/settings/page.tsx
@@ -2,7 +2,7 @@
 
 import Image from 'next/image';
 import { useState, useEffect, useRef } from 'react';
-import { useParams } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
 import { useProject } from '@/hooks/useProjects';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -46,8 +46,9 @@ const PROJECT_ICONS = ['📁', '🚀', '💼', '🎯', '📊', '🔧', '💡', '
 
 export default function ProjectSettingsPage() {
   const params = useParams();
+  const router = useRouter();
   const projectId = params.projectId as string;
-  const { project, members, isLoading, update, addMember, removeMember, updateRole } = useProject(projectId);
+  const { project, members, isLoading, update, archive, remove, addMember, removeMember, updateRole } = useProject(projectId);
 
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
@@ -55,6 +56,8 @@ export default function ProjectSettingsPage() {
   const [icon, setIcon] = useState('');
   const [iconUrl, setIconUrl] = useState<string | undefined>(undefined);
   const [isSaving, setIsSaving] = useState(false);
+  const [isArchiving, setIsArchiving] = useState(false);
+  const [isDeletingProject, setIsDeletingProject] = useState(false);
   const [isUploadingIcon, setIsUploadingIcon] = useState(false);
   const [isPreparingIconCrop, setIsPreparingIconCrop] = useState(false);
   const [cropperOpen, setCropperOpen] = useState(false);
@@ -365,6 +368,37 @@ export default function ProjectSettingsPage() {
       alert('タスクの削除に失敗しました');
     } finally {
       setDeletingTaskId(null);
+    }
+  };
+
+  const handleArchiveProject = async () => {
+    if (!confirm('このプロジェクトをアーカイブしますか？')) return;
+
+    setIsArchiving(true);
+    try {
+      await archive();
+      router.push('/projects');
+    } catch (error) {
+      console.error('Failed to archive project:', error);
+      alert('プロジェクトのアーカイブに失敗しました');
+    } finally {
+      setIsArchiving(false);
+    }
+  };
+
+  const handleDeleteProject = async () => {
+    if (!project.isArchived) return;
+    if (!confirm('このプロジェクトを完全に削除しますか？この操作は取り消せません。')) return;
+
+    setIsDeletingProject(true);
+    try {
+      await remove();
+      router.push('/projects');
+    } catch (error) {
+      console.error('Failed to delete project:', error);
+      alert('プロジェクトの削除に失敗しました');
+    } finally {
+      setIsDeletingProject(false);
     }
   };
 
@@ -922,18 +956,35 @@ export default function ProjectSettingsPage() {
                   プロジェクトを非表示にします
                 </p>
               </div>
-              <Button variant="outline">アーカイブ</Button>
+              <Button
+                variant="outline"
+                onClick={handleArchiveProject}
+                disabled={isArchiving || project.isArchived}
+              >
+                {isArchiving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                {project.isArchived ? 'アーカイブ済み' : 'アーカイブ'}
+              </Button>
             </div>
             <Separator />
             <div className="flex items-center justify-between">
               <div>
                 <p className="font-medium text-red-600">プロジェクトを削除</p>
                 <p className="text-sm text-muted-foreground">
-                  プロジェクトとすべてのデータが完全に削除されます
+                  {project.isArchived
+                    ? 'プロジェクトとすべてのデータが完全に削除されます'
+                    : '削除するには先にプロジェクトをアーカイブしてください'}
                 </p>
               </div>
-              <Button variant="destructive">
-                <Trash2 className="mr-2 h-4 w-4" />
+              <Button
+                variant="destructive"
+                onClick={handleDeleteProject}
+                disabled={!project.isArchived || isDeletingProject}
+              >
+                {isDeletingProject ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <Trash2 className="mr-2 h-4 w-4" />
+                )}
                 削除
               </Button>
             </div>

--- a/src/app/(dashboard)/projects/page.tsx
+++ b/src/app/(dashboard)/projects/page.tsx
@@ -76,7 +76,6 @@ export default function ProjectsPage() {
               key={project.id}
               project={project}
               onArchive={handleArchive}
-              onDelete={handleDelete}
             />
           ))}
         </div>

--- a/src/components/project/ProjectCard.tsx
+++ b/src/components/project/ProjectCard.tsx
@@ -101,13 +101,15 @@ export function ProjectCard({
                 アーカイブ
               </DropdownMenuItem>
             )}
-            <DropdownMenuItem
-              onClick={() => onDelete?.(project.id)}
-              className="text-red-600"
-            >
-              <Trash2 className="mr-2 h-4 w-4" />
-              削除
-            </DropdownMenuItem>
+            {project.isArchived && onDelete && (
+              <DropdownMenuItem
+                onClick={() => onDelete(project.id)}
+                className="text-red-600"
+              >
+                <Trash2 className="mr-2 h-4 w-4" />
+                削除
+              </DropdownMenuItem>
+            )}
           </DropdownMenuContent>
         </DropdownMenu>
       </CardHeader>

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -284,6 +284,28 @@ export function useProject(projectId: string | null) {
     [projectId]
   );
 
+  // Archive project (real-time subscription will handle state updates)
+  const archive = useCallback(async () => {
+    if (!projectId) return;
+    try {
+      await archiveProject(projectId, true);
+    } catch (err) {
+      setError(err as Error);
+      throw err;
+    }
+  }, [projectId]);
+
+  // Delete an archived project
+  const remove = useCallback(async () => {
+    if (!projectId) return;
+    try {
+      await deleteProject(projectId);
+    } catch (err) {
+      setError(err as Error);
+      throw err;
+    }
+  }, [projectId]);
+
   // Add member
   const addMember = useCallback(
     async (userId: string, role: ProjectRole) => {
@@ -338,6 +360,8 @@ export function useProject(projectId: string | null) {
     isLoading,
     error,
     update,
+    archive,
+    remove,
     addMember,
     removeMember,
     updateRole,

--- a/src/lib/firebase/firestore.projects.test.ts
+++ b/src/lib/firebase/firestore.projects.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  deleteDoc: vi.fn(),
+  doc: vi.fn(() => 'PROJECT_REF'),
+  getDoc: vi.fn(),
+  getFirebaseDb: vi.fn(() => 'DB'),
+}));
+
+vi.mock('firebase/firestore', () => ({
+  collection: vi.fn(),
+  doc: mocks.doc,
+  addDoc: vi.fn(),
+  updateDoc: vi.fn(),
+  deleteDoc: mocks.deleteDoc,
+  getDoc: mocks.getDoc,
+  getDocs: vi.fn(),
+  setDoc: vi.fn(),
+  query: vi.fn(),
+  where: vi.fn(),
+  orderBy: vi.fn(),
+  onSnapshot: vi.fn(),
+  serverTimestamp: vi.fn(),
+  writeBatch: vi.fn(),
+  Timestamp: class Timestamp {},
+  documentId: vi.fn(),
+  limit: vi.fn(),
+}));
+
+vi.mock('./config', () => ({
+  getFirebaseDb: mocks.getFirebaseDb,
+}));
+
+import { deleteProject } from './firestore';
+
+describe('deleteProject', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects deletion while the project is active', async () => {
+    mocks.getDoc.mockResolvedValue({
+      exists: () => true,
+      data: () => ({ isArchived: false }),
+    });
+
+    await expect(deleteProject('project-1')).rejects.toThrow(
+      'プロジェクトを削除するには先にアーカイブしてください'
+    );
+    expect(mocks.deleteDoc).not.toHaveBeenCalled();
+  });
+
+  it('deletes an archived project', async () => {
+    mocks.getDoc.mockResolvedValue({
+      exists: () => true,
+      data: () => ({ isArchived: true }),
+    });
+
+    await deleteProject('project-1');
+
+    expect(mocks.doc).toHaveBeenCalledWith('DB', 'projects', 'project-1');
+    expect(mocks.deleteDoc).toHaveBeenCalledWith('PROJECT_REF');
+  });
+});

--- a/src/lib/firebase/firestore.ts
+++ b/src/lib/firebase/firestore.ts
@@ -193,8 +193,15 @@ export async function updateProject(
 
 export async function deleteProject(projectId: string): Promise<void> {
   const db = getFirebaseDb();
+  const projectRef = doc(db, 'projects', projectId);
+  const projectSnapshot = await getDoc(projectRef);
+
+  if (projectSnapshot.exists() && projectSnapshot.data().isArchived !== true) {
+    throw new Error('プロジェクトを削除するには先にアーカイブしてください');
+  }
+
   // Note: In production, use Cloud Functions to cascade delete subcollections
-  await deleteDoc(doc(db, 'projects', projectId));
+  await deleteDoc(projectRef);
 }
 
 export async function archiveProject(


### PR DESCRIPTION
## 変更内容

- 設定画面のアーカイブボタンを実動化し、完了後にプロジェクト一覧へ戻す
- アクティブなプロジェクトでは削除操作を無効化／非表示にする
- アーカイブ済みプロジェクトだけ完全削除できるようにする
- 削除条件をUI、クライアント削除処理、Firestoreルールの3層で強制する
- PostCSSとwebsocket-driverを安全なバージョンへ固定し、依存監査を解消する
- アーカイブ／削除フローと削除ガードの回帰テストを追加する

## 原因

設定画面のアーカイブボタンにクリック処理が接続されておらず、削除経路もプロジェクトのアーカイブ状態を検証していませんでした。また、Next.jsとFirebaseの推移依存に既知の脆弱性が残っていました。

## 影響

ユーザーはプロジェクトを直接削除できなくなり、必ず復元可能なアーカイブ操作を経由します。アーカイブ済み一覧からは従来どおり復元または完全削除できます。

## 検証

- `npm run audit` — 0 vulnerabilities
- `npm run lint` — pass
- `npm run test:run` — 24 files / 158 tests pass
- `npm run build` — pass
- `npm run test:e2e:smoke` — 6 tests pass

Closes #82
